### PR TITLE
♻️  Incremental Static Regeneration On Climb Log

### DIFF
--- a/pages/climb-log.js
+++ b/pages/climb-log.js
@@ -235,6 +235,7 @@ export async function getStaticProps() {
     props: {
       allClimbs: response,
     },
+    revalidate: 60,
   }
 }
 


### PR DESCRIPTION
Adding [Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration) on the Climb Log, this will re-render the page every minute without re-rendering the entire site.

This might help out with the images in the climb log popover. If I'm thinking about this right, the climb log will make a new request to the Notion API every minute and get the updated temp URL for the cover image? We can definitely change the minute to however long it takes a URL to expire (looks like maybe 3hrs?). 