### PR TITLE
🥾 Display Footer on home (override next/image bug)

### DIFF
--- a/components/Card.module.css
+++ b/components/Card.module.css
@@ -50,10 +50,6 @@
 }
 
 @media (max-width: 1024px) {
-  .card {
-    max-width: 75vw;
-  }
-
   .cardText {
     padding: 1vw 3vw;
   }

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -4,6 +4,7 @@ import { FiExternalLink } from 'react-icons/fi'
 import {
   CONNECT as connectLinks,
   EXPLORE as exploreLinks,
+  METADATA,
   REFERRALS as referralLinks,
 } from '../utils/constants'
 
@@ -45,7 +46,9 @@ export default function Footer() {
 
         <div className={styles.footerLogo}>
           <Logo theme="dark" />
-          <small>© 2022 Kylie Stewart</small>
+          <small>
+            © {new Date().getFullYear()} {METADATA.FULL_NAME}
+          </small>
         </div>
       </div>
     </footer>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -18,7 +18,6 @@ export default function Layout({ children, home }) {
       <div className={!home ? styles.wrapper : styles.landingPage}>
         {home ? <LandingNavigation /> : <Navigation />}
         <main>{!loading ? children : <Loading />}</main>
-
         {!home && (
           <div className={utilStyles.backToHome}>
             <Link href="/">
@@ -27,8 +26,7 @@ export default function Layout({ children, home }) {
           </div>
         )}
       </div>
-
-      {!home && <Footer />}
+      <Footer />
     </>
   )
 }

--- a/components/Layout.module.css
+++ b/components/Layout.module.css
@@ -7,8 +7,8 @@
   display: grid;
   grid-gap: 2.5em;
   grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
-  padding: 0 3em;
-  margin: 2.2em 0;
+  padding: 0 10vw;
+  margin: 2.2em auto;
 }
 
 .wrapper {

--- a/components/Navigation.module.css
+++ b/components/Navigation.module.css
@@ -32,6 +32,9 @@
 
 .navigation a {
   color: #1b1b1b;
+  padding: 0.25em;
+  margin: 0 0.25em;
+  font-weight: 400;
 }
 
 .navigation a:hover {

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -49,39 +49,41 @@ export default function BlogLandingPage({ allPostsData }) {
 
   return (
     <Layout>
-      <div className={styles.blogHeaders}>
-        <h1 className={utilStyles.headingXl}>Blog</h1>
-        <section className={styles.categoryFilterWrapper}>{buildCategories()}</section>
-      </div>
+      <div className={styles.blogPage}>
+        <div className={styles.blogHeaders}>
+          <h1 className={utilStyles.headingXl}>Blog</h1>
+          <section className={styles.categoryFilterWrapper}>{buildCategories()}</section>
+        </div>
 
-      <section
-        className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${styles.blogSection}`}
-      >
-        <ul className={utilStyles.list}>
-          {allPostsData.map(({ id, category, date, preview, title }) => (
-            <li
-              className={utilStyles.listItem}
-              key={id}
-              style={{
-                display:
-                  viewCategory === category || viewCategory === CATEGORY_TYPE.ALL
-                    ? 'block'
-                    : 'none',
-              }}
-            >
-              <Link href="/[category]/[id]" as={`/${category}/${id}`}>
-                <a className={styles.blogPostHeading}>{title}</a>
-              </Link>
-              <br />
-              <small className={`${utilStyles.lightText} ${styles.blogItemCategory}`}>
-                <FormattedDate dateString={date} />{' '}
-                <Category category={category} pushToRouter={false} />
-              </small>
-              <small className={utilStyles.listItem}>{preview}</small>
-            </li>
-          ))}
-        </ul>
-      </section>
+        <section
+          className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${styles.blogSection}`}
+        >
+          <ul className={utilStyles.list}>
+            {allPostsData.map(({ id, category, date, preview, title }) => (
+              <li
+                className={utilStyles.listItem}
+                key={id}
+                style={{
+                  display:
+                    viewCategory === category || viewCategory === CATEGORY_TYPE.ALL
+                      ? 'block'
+                      : 'none',
+                }}
+              >
+                <Link href="/[category]/[id]" as={`/${category}/${id}`}>
+                  <a className={styles.blogPostHeading}>{title}</a>
+                </Link>
+                <br />
+                <small className={`${utilStyles.lightText} ${styles.blogItemCategory}`}>
+                  <FormattedDate dateString={date} />{' '}
+                  <Category category={category} pushToRouter={false} />
+                </small>
+                <small className={utilStyles.listItem}>{preview}</small>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
     </Layout>
   )
 }

--- a/styles/about.module.css
+++ b/styles/about.module.css
@@ -13,12 +13,15 @@
 
 .brandLink {
   color: #0065b8;
+  text-decoration: none;
+  font-weight: 600;
+  vertical-align: middle;
+  box-shadow: inset 0 -0.07em #3992db, inset 0 -0.15em #0065b8;
 }
 
 .brandLink:hover {
-  box-shadow: inset 0 -75px 0 0 #0065b8;
+  box-shadow: inset 0 -2em 0 0 #0065b8cb;
   color: white;
-  border-radius: 15px;
 }
 
 @media (max-width: 1024px) {

--- a/styles/blog.module.css
+++ b/styles/blog.module.css
@@ -1,3 +1,8 @@
+.blogPage {
+  width: 50vw;
+  margin: 0 auto;
+}
+
 .blogItemCategory {
   display: flex;
   align-items: center;
@@ -13,13 +18,11 @@
   text-align: center;
   text-decoration: none;
   color: #757575;
-  padding: 0.25em;
+  padding: 0.05em;
 }
 
 .blogNavigation a:hover {
-  box-shadow: inset 0 -75px 0 0 #4e8a00;
-  color: white;
-  border-radius: 15px;
+  box-shadow: inset 0 -0.1em 0 0 #757575;
 }
 
 .blogNavigationSeparator {
@@ -34,6 +37,8 @@
   font-size: 1.5rem;
   color: #020202;
   padding: 0;
+  box-shadow: none;
+  font-weight: 400;
 }
 
 .blogPostHeading:hover {
@@ -47,6 +52,10 @@
 }
 
 @media (max-width: 1024px) {
+  .blogPage {
+    width: auto;
+  }
+
   .blogNavigationSeparator {
     display: flex;
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -62,13 +62,22 @@ button:hover {
 a {
   color: #4e8a00;
   text-decoration: none;
-  padding: 0.25em;
+  padding: 0.07em;
 }
 
-a:hover {
-  box-shadow: inset 0 -75px 0 0 #4e8a00;
+p a,
+ul a {
+  color: #4e8a00;
+  text-decoration: none;
+  font-weight: 600;
+  vertical-align: middle;
+  box-shadow: inset 0 -0.07em #7fce17, inset 0 -0.15em #4e8a00;
+}
+
+p a:hover,
+ul a:hover {
+  box-shadow: inset 0 -2em 0 0 #4e8a00cb;
   color: white;
-  border-radius: 15px;
 }
 
 caption {

--- a/styles/utils.module.css
+++ b/styles/utils.module.css
@@ -1,16 +1,35 @@
+@keyframes shake {
+  0% {
+    transform: translate(1px, 1px) rotate(0deg);
+  }
+  20% {
+    transform: translate(-1px, -2px) rotate(-1deg);
+  }
+  40% {
+    transform: translate(-3px, 0px) rotate(1deg);
+  }
+  60% {
+    transform: translate(3px, 2px) rotate(0deg);
+  }
+  80% {
+    transform: translate(1px, -1px) rotate(1deg);
+  }
+  100% {
+    transform: translate(-1px, 2px) rotate(-1deg);
+  }
+}
+
 .backToHome {
   margin: 3rem 0;
 }
 
 .backToHome a {
   text-decoration: none;
-  color: #ff953d;
 }
 
-.backToHome a:hover {
-  box-shadow: inset 0 -75px 0 0 #ff953d;
-  color: white;
-  border-radius: 15px;
+.backToHome:hover {
+  animation: shake 0.3s;
+  animation-iteration-count: infinite;
 }
 
 .centerText {

--- a/styles/utils.module.css
+++ b/styles/utils.module.css
@@ -87,7 +87,7 @@
   align-items: center;
 }
 
-.hiddenForMobile > div:first-child{
+.hiddenForMobile > div:first-child {
   display: block !important;
 }
 

--- a/styles/utils.module.css
+++ b/styles/utils.module.css
@@ -87,6 +87,10 @@
   align-items: center;
 }
 
+.hiddenForMobile > div:first-child{
+  display: block !important;
+}
+
 @media (max-width: 1024px) {
   .hiddenForMobile {
     display: none;

--- a/utils/data/climbs.js
+++ b/utils/data/climbs.js
@@ -47,7 +47,7 @@ const formatClimbs = (response) => {
  * featured on the home page
  */
 const fetchMostRecentClimbs = async () => {
-  const config = getDatabaseQueryConfig(null, 3)
+  const config = getDatabaseQueryConfig(null, 5)
   config.sorts = [{ property: 'date', direction: 'descending' }]
   let response = await notion.databases.query(config)
   return formatClimbs(response.results)


### PR DESCRIPTION
Using a targeted `!important` style to stamp out the `display: inline-block` next/image sets to finally get rid of that 1px padding. Now the Footer sits directly beneath the bottom image without whitespace. 🙌