### PR TITLE
🌅 Image optimization for blog posts

### DIFF
--- a/blog/gear/14er-pack-list.md
+++ b/blog/gear/14er-pack-list.md
@@ -7,6 +7,10 @@ I'm incredibly embarrassed to admit it, but I used to think you could get away w
 
 When preparing for any high elevation peak, I follow a formula to pack my bag the night before. Hopefully my method helps you pack for your own peaks, too! Or at least encourages you to consider some new items to bring along on your next ascent.
 
+![Stephen's Gulch](https://live.staticflickr.com/65535/51795047198_68e246b5e4_c.jpg)
+
+_The view from Stephen's Gulch, seen while climbing my first high peak in July 2019._
+
 ## Clothes
 
 The first (and maybe most important) items to pack for a 14er are the clothes you'll wear.
@@ -31,6 +35,10 @@ Whatever you don't wear, you should have packed. Some of these items could be co
 - Extra **hoodie**. Even on top of the wool layer, it's nice to have one with a cinched hood ready to layer under your wind layer if things start to get intense (as they often do above 13k).
 - Extra **socks**, **gloves**, **beanie**. Again, in all seasons. Summer in Front Range isn't quite the same as summer at double the elevation.
 
+![Descending Uncompahgre](https://live.staticflickr.com/65535/51789832732_4de85ea534_b.jpg)
+
+_Descending Uncompahgre's south ridge in October 2021, my climbing partner Luis in sight._
+
 ## Survival Gear
 
 It's important to have a couple of different types of survival gear on hand when you're doing anything at altitude. I've split my survival gear into two different cases:
@@ -51,6 +59,10 @@ Not only can you use a SatCom device like the Garmin InReach to text your loved 
 
 Again, these aren't necessary for folks just getting started, but if you find yourself hiking solo more often than with a group, or want to offer some peace of mind to your far-away relatives, purchasing and carrying a SatCom is an excellent way to do this.
 
+![Redcloud Peak](https://live.staticflickr.com/65535/51807025013_a5d55db3be_b.jpg)
+
+_Dropping off of Redcloud Peak to ascend its neighbor, Sunshine Peak. July 2021._
+
 ## Miscellaneous Gear
 
 In addition to the clothes and emergency gear listed above, I carry a subset of standard items on nearly any hike. Even on shorter trail runs where I only wear a hydration vest, I will typically carry a couple of the following items just in case:
@@ -61,6 +73,10 @@ In addition to the clothes and emergency gear listed above, I carry a subset of 
 - **Multi-tool**: One with pliers is especially nice, you'd be surprised how often this tool is used to quick-fix gear on the trail.
 - **Duct tape**: A few feet of duct tape rolled around a Sharpie and a handful of small zipties can go a long way in a number of situations. I keep these in a dry bag with some other emergency gear I don't want getting wet at the bottom of my 28L bag.
 
+![Ally on Lindsey Ridge](https://live.staticflickr.com/65535/51817988165_febd3f2b4f_b.jpg)
+
+_My climbing partner Ally moving along Mount Lindsey's lower ridge._
+
 ## Snacks & Hydration
 
 One of the keys to _comfortably_ surviving your first 14er peak is caloric intake. Pack more snacks than you think you'll want to consume. On top of that, consider variety in your selection. Sometimes altitude sickness strikes in strange ways and you'll find yourself nauseous at the thought of a snack you would typically inhale without hesitation. Giving yourself more than just a sweet or savory option can go a long way in helping counter this.
@@ -69,3 +85,7 @@ One of the keys to _comfortably_ surviving your first 14er peak is caloric intak
 - Single-use **apple sauces** have also been a go-to for me as of late. They're a little less sugary than the fruit snacks so I justify them as a slightly healthier breakfast item.
 - I've started packing **liquid powder packs** to substitute Gatorade on summits. This allows me to drink multiple throughout the hike: every time the bottle is emptied, I can refill it using more water and a second or even third rehydration pack.
 - **Protein bars** are a another staple I haven't gotten sick of... yet. Especially when there are so many different brands and flavors available. Bobo's lemon or Clif's hazelnut butter bars in particular, though, are top notch.
+
+![Granite Pass Squirrel {768x480}](https://live.staticflickr.com/65535/51795298419_4261144216_b.jpg)
+
+_A squirrel enjoying a snack on Granite Pass, just below the Longs Peak boulderfield._

--- a/blog/gear/first-winter-peak.md
+++ b/blog/gear/first-winter-peak.md
@@ -13,13 +13,14 @@ To clarify, when I call a peak a 'snowflake', I am referring to the time of year
 
 As a frequent user of the [14ers.com](https://www.14ers.com) forum, I understand this term to derive from the ❄️ snowflake emoji your peak list gains when you complete a climb during calendar winter. There are likely other terms used among mountaineers for this accomplishment, but the claim is the same: summiting a peak during some of the roughest possible conditions.
 
-![peak-checklist-screenshot](https://live.staticflickr.com/65535/51758027680_55a2260745_w.jpg)
+![Peak Checklist Screenshot {399x310}](https://live.staticflickr.com/65535/51758027680_55a2260745_w.jpg)
 
 _A screenshot of my peak checklist on 14ers.com. See how the Snowflake appears opposite the standard mark of completion._
 
 ## Why Climb in the Winter?
 
-![la-plata-snowflake](https://live.staticflickr.com/65535/51757385408_0386c75cb2_k.jpg)
+![La Plata Snowflake {768x432}](https://live.staticflickr.com/65535/51757385408_0386c75cb2_k.jpg)
+
 _Ascending La Plata in March of 2021. We were post-holing up to our waist at times._
 
 Colorado winters up in the alpine are something special. It’s not easy to convey the serenity one feels when slogging up a snowy hill on a 0℉ winter morning. Or how a sunrise inversion reflecting off of a fresh blanket of snow can stay in your mind for years. Or the accomplishment one feels when summiting a 14,000 foot peak despite icy winds and waist-deep pockets of powder. And if you’re a downhill enthusiast, you’ll find yourself at the top of some of the best ski lines in the world. The payoff for your effort seems tenfold in the winter, and I would argue the peaks look their best wearing a fresh white coat.
@@ -42,7 +43,7 @@ Some free resources you can use to learn more about recreating in avalanche terr
 
 - [In Person & Virtual Events offered by Friends of Berthoud Pass](https://www.berthoudpass.org/event-schedule.html)
 
-![group-ascending-la-plata](https://live.staticflickr.com/65535/51722449700_9dfcb5609d_k.jpg)
+![Group Ascending La Plata {768x432}](https://live.staticflickr.com/65535/51722449700_9dfcb5609d_k.jpg)
 
 _A look back at our group ascending La Plata Peak._
 
@@ -80,7 +81,8 @@ In addition to the standard safety and shelter items I outline in my [post about
 
 - An **ice axe** isn't necessary for most class one and two climbs, but it can make descending an icy slope of any grade just a bit safer and easier. You cold use hiking poles to stabilize you for a descent, but an ice axe can be a worthwhile investment as it helps you self-arrest if you lose your footing.
 
-![mount-democrat-snowflake](https://live.staticflickr.com/65535/51758010860_9b71276d75_k.jpg)
+![Democrat Snowflake Ascent](https://live.staticflickr.com/65535/51758010860_9b71276d75_k.jpg)
+
 _Ascending Mount Democrat in January of 2021, Mount Cameron in the background._
 
 ## Finding Winter Routes
@@ -90,7 +92,7 @@ Without repeating too much info from the free resources I’ve linked above, the
 - **Slope Angle**
 
   One of the most straightforward ways to assess risk on a winter route is identifying the slope angle you might be traveling under or across. The aspect of the mountain you intend to climb can also impact slide risk (e.g. the north side gets less sun in winter months, causing more snow to stay accumulated a.k.a. slope load), but seeing your line on a topographical map (I like the slope angle filter on [gaia](https://www.gaiagps.com)’s app) can be a much more clear-cut way to identify risk.
-  ![screenshot comparing two route’s angles](https://live.staticflickr.com/65535/51758050945_e4c3de86f3_k.jpg)
+  ![Screenshot Comparing the Route's Angles {768x341}](https://live.staticflickr.com/65535/51758050945_e4c3de86f3_k.jpg)
 
   _Can you see why the line on the right might be riskier?_
 
@@ -123,6 +125,6 @@ I'm not saying any of these are easy, but there are some winter routes with lowe
   - Technically a bushwhack made a little easier with snowpack, this approach to Humboldt Peak is the safer option in winter months as you don't pass under the potentially loaded slopes that the South Colony Lakes road snakes through. If you're lucky enough to find a trench, this snowshoe is a little less of a slog, but without one you'll be breaking trail for 3 or so miles in the trees up the Rainbow Trail before you get above treeline.
   - _Roundtrip stats:_ 13 miles & 4,900 feet of gain.
 
-![la-plata-gain](https://live.staticflickr.com/65535/51722450695_e544cbd385_k.jpg)
+![Gaining La Plata's Headwall {768x264}](https://live.staticflickr.com/65535/51722450695_e544cbd385_k.jpg)
 
 _Just after we gained the headwall of La Plata's standard route, the peak out of sight on the other side of this hump along the ridgeline._

--- a/blog/hike/solo-citadel.md
+++ b/blog/hike/solo-citadel.md
@@ -15,13 +15,13 @@ The approach to this climb is an easy and popular day hike up Herman Gulch. At t
 
 There are wildflowers aplenty if you're hiking this in the early summer. Late June through mid-July is considered the peak season to see these flowers, but it can vary year to year. Being such a lush valley, you can find yourself among some large crowds if you choose to hike it on a weekend during this time of year.
 
-![Herman Gulch Ascent](https://live.staticflickr.com/65535/51848193323_d26506f354_b.jpg)
+![Herman Gulch Ascent {768x484}](https://live.staticflickr.com/65535/51848193323_d26506f354_b.jpg)
 
 _Wildflowers seen on the ascent of Herman Gulch._
 
 After turning left at the lake and heading up a narrow trail to a marshy area, you'll lose sight of cairns. As is the case with many 13ers, there's another path visible gaining the shoulder that I chose to cut the edge of the marsh to get to, but I'm sure there are alternatives that will take you directly to this path. For what it's worth, I did try to target that trail on my descent but did not find any well-traveled or marked connection back to the main path. You will need to bushwhack a little bit to get to this peak.
 
-![Above the Basin](https://live.staticflickr.com/65535/51848192873_34fc12320d_b.jpg)
+![Above the Basin {768x527}](https://live.staticflickr.com/65535/51848192873_34fc12320d_b.jpg))
 
 _Looking back after leaving the basin to gain The Citadel's southern shoulder._
 
@@ -31,13 +31,13 @@ Once you gain the saddle between Hagar and The Citadel, Golden Bear and a sectio
 
 After switching up the ridge through some steeper terrain, I finally got a good look at the climbing ahead.
 
-![Facing the Climb](https://live.staticflickr.com/65535/51848131036_8f62019a9b_b.jpg)
+![Facing the Climb {768x524}](https://live.staticflickr.com/65535/51848131036_8f62019a9b_b.jpg)
 
 _Looking at the route options to ascend: gully (C3) is to the left, chutes (C4+) to the right._
 
 At this point I chose to put my helmet on and stash my poles so they wouldn't get in the way of my ascent. I knew there was a vertical class 4+ (debatably class 5, some folks recommended rope) chute to the right that I wanted to try. Upon closer inspection, it looked solid and I felt confident going for this 30 foot wall alone.
 
-![vertical](https://live.staticflickr.com/65535/51848781765_7694b723da_b.jpg)
+![Looking up the Chute {576x768}](https://live.staticflickr.com/65535/51848781765_7694b723da_b.jpg)
 
 _Looking towards the chute I chose to climb, visible as a crack on the far right._
 
@@ -49,7 +49,7 @@ Moving up this wall was the highlight of my day, and when I topped out after 10 
 
 Looking back, I saw a leftover rope and anchor from someone's climb prior.
 
-![vertical](https://live.staticflickr.com/65535/51848781220_8f0d9eec2e_b.jpg)
+![Leftover climbing tools {576x768}](https://live.staticflickr.com/65535/51848781220_8f0d9eec2e_b.jpg)
 
 _Leftover rope and anchor is visible at the bottom of this photo, the chute I've just climbed is on the right._
 
@@ -57,7 +57,7 @@ This was a humbling sight and brought back the reality that I was only halfway d
 
 The first high point I gained initially seemed like the summit and even had a summit registry, but was only 13,108' at its highest. The true summit was still maybe a quarter mile and gully away. I took a break on this first high point, read the registry (found out it had only been placed in 2018), and had a snack before continuing on to the 13,294' summit.
 
-![False Summit](https://live.staticflickr.com/65535/51848780770_a751d7411d_b.jpg)
+![False Summit {768x514}](https://live.staticflickr.com/65535/51848780770_a751d7411d_b.jpg)
 
 _Standing on the initial false summit of The Citadel, looking over to the real summit block._
 
@@ -65,13 +65,13 @@ Traversing between these two points took me only 6 minutes according to my GPX t
 
 Gaining the second summit was easier than descending the first. The summit itself was a set of toothy rocks, all about 6-8 feet tall. One can scramble up to the top of these teeth if you're up for a challenge, which I did.
 
-![True Summit](https://live.staticflickr.com/65535/51848780400_4210213e27_b.jpg)
+![True Summit {768x524}](https://live.staticflickr.com/65535/51848780400_4210213e27_b.jpg)
 
 _Looking over to Pettingell from the Citadel’s true summit._
 
 The views of the surrounding peaks from this summit is expansive and the first high point I had come over looked like a single, sharp tooth from the higher angle. The sharp lines contrasted with wide basins makes this summit feel more like an Elk peak than a Front range one.
 
-![vertical](https://live.staticflickr.com/65535/51817385803_e157b9a084_b.jpg)
+![Summit Spire {591x768}](https://live.staticflickr.com/65535/51817385803_e157b9a084_b.jpg))
 
 _Looking back to the first high point from Citadel's true summit._
 
@@ -81,13 +81,13 @@ Descending the gully to The Citadel's west was as loose and unsupported as I had
 
 Getting back down the shoulder was simple and I still hadn't seen a soul above this ridge. I wouldn't see anyone else until I linked back up with Herman Gulch's main trail. Getting back to the main trail, however, was a bushwhack and a half, with the occasional misstep into deep wetland. I kept my impact on the land at the forefront of my mind as I tried to avoid stepping on any fragile land, plants, or animals.
 
-![Wildflowers on the Descent](https://live.staticflickr.com/65535/51847156697_8c2ed660d8_b.jpg)
+![Wildflowers on the Descent {768x545}](https://live.staticflickr.com/65535/51847156697_8c2ed660d8_b.jpg)
 
 _Bushwhacking through the a wildflower-filled field to return to the main Herman Gulch trail._
 
 There are two river crossings worth noting but no real trail to follow. The second and largest river crossing was about a half mile from the main trail connection and from there was an easy 46 minute walk out to the lot.
 
-![vertical](https://live.staticflickr.com/65535/51847156292_9f154d1979_b.jpg)
+![River Crossing {605x768}](https://live.staticflickr.com/65535/51847156292_9f154d1979_b.jpg)
 
 _One of the two river crossings required to get back to the main trail. This one had a stable rock path through, even though it was rushing._
 

--- a/blog/hike/winter-white-whale.md
+++ b/blog/hike/winter-white-whale.md
@@ -9,7 +9,7 @@ In the fall of 2020, The Year of the Pandemic, I was let go from my role as a so
 
 Humboldt was my third "snowflake" 14er attempt. When I say "snowflake", I'm referring to a peak obtained within calendar winter (this window typically begins late December and ends mid-March). The qualifications being set to such a limited period of time, during which conditions are usually the worst a hiker can experience, snowflake summits are something to be proud of. A bragging point for some experienced mountaineers. I had successfully ascended Pikes Peak and Mount Democrat (two class two routes, one of which I had climbed in the summer prior) that calendar winter and I was eager to bag a few more. Humboldt seemed like a reasonable next goal, and being in the Sangres it had a special appeal.
 
-![mount-democrat](https://live.staticflickr.com/65535/51731522372_81e71a21de_b.jpg)
+![Snowy Democrat {768x353}](https://live.staticflickr.com/65535/51731522372_81e71a21de_b.jpg)
 
 _A photo from my snowflake ascent of Mount Democrat the same year._
 
@@ -23,13 +23,13 @@ The next morning, everyone was quick to wake and we set out for the 2WD parking 
 
 The first couple of miles snowshoeing the road before the Rainbow Trail turn were uneventful. I think we were all eager for the first sign of alpenglow and hoping to position ourselves for a killer view before it happened. As we gained the Rainbow Trail ridge and began our bushwhack up the east ridge, light hit our backs and warmed the scene around us. Navigating through the trees, the snow glistened like it had been coated with glitter, while the fresh powder made it seem like no one had broken trail in several months.
 
-![first-light](https://live.staticflickr.com/65535/51732591448_cbc12127da_k.jpg)
+![First Light {768x576}](https://live.staticflickr.com/65535/51732591448_cbc12127da_k.jpg)
 
 _First light seen along Humboldt's east ridge approach._
 
 About 3.5 miles in, we realized we were all working especially hard but not seeming to gain quite as much elevation as is to be expected at this point along the trail. It seemed like we were moving straight, not up. Our group had begun to drift, with two leading and two holding up the rear, just barely out of audible communication distance. We later learned that the leading group had unintentional followed some SAR tracks off route, but we were all determined to get up this thing so we continued to trudge even after we realized we had made a mistake.
 
-![moonset](https://live.staticflickr.com/65535/51732583708_ed244b2cf5_k.jpg)
+![The Moonset {768x576}](https://live.staticflickr.com/65535/51732583708_ed244b2cf5_k.jpg)
 
 _The moonset, seen right around first light._
 
@@ -37,13 +37,13 @@ Reaching treeline, we were all burnt. The group splintered even further. Some of
 
 While one member of our group did manage to summit Humboldt Peak that day, three of us had to turn around as close as 200' below the summit proper. "It's right there," some strangers descending past us pointed out. "That's not a false summit, you're probably only 10 minutes away." I don't think I even replied to them, just wearily nodded. We knew we were close, but we also knew how bad we felt. It just wasn't going to be worth it. Altitude sickness is a force to be reckoned with.
 
-![humboldt-ridge.jpg](https://live.staticflickr.com/65535/51732590893_34f1d33708_k.jpg)
+![Humboldt Ridge {768x498}](https://live.staticflickr.com/65535/51732590893_8120f419b4_b.jpg)
 
 _So close, yet so far. This is where we turned around._
 
 ## The Second Attempt
 
-One month later, Kyle and I booked another dog sitter and made the plan to attempt this beast again. It was still calendar winter so we stood to gain the snowflake. Since our first attempt of Humboldt, we had successfully summited La Plata and Bierstadt so we were both feeling good about our stamina.
+One month later, Kyle and I booked another dog sitter and made the plan to attempt this beast again. It was still calendar winter so we stood to gain the snowflake. Since our first attempt of Humboldt, we had successfully summitted La Plata and Bierstadt so we were both feeling good about our stamina.
 
 We got up to the same false summit block just before the final summit ridge and Kyle's snowshoe failed him. Flipping as he ascended a slope and yanking on a tendon in his knee, we made the immediate choice once again to turn around and try again another day.
 
@@ -53,13 +53,13 @@ One more month went by before I tried for Humboldt again... Well, I admit, one m
 
 I passed all of the checkpoints where we had turned around on trips prior. Passed the vomit-break tree, passed the false summit, passed the section 200' below the summit where we first made the call, and finally found myself on top of Humboldt Peak.
 
-![vertical](https://live.staticflickr.com/65535/51732592028_0bc574b2d5_k.jpg)
+![Humboldt Peak's Summit {576x768}](https://live.staticflickr.com/65535/51732592028_0bc574b2d5_k.jpg)
 
 _Photo of my summit sign on top of Humboldt Peak, Crestone Peak & Needle in the background._
 
 The east ridge route up to Humboldt Peak is funny because you don't see the Crestones until you're on the summit proper. You do, however, get beautiful views once you start to gain the slopes around treeline, see all kinds of wildlife, and the neighboring Centennials show off for you most of the way up. But when you're standing on the summit block, the Crestones are the sight that make this whole day worth it. And you can only see those two from the 14,064' summit.
 
-![humboldt-summit](https://live.staticflickr.com/65535/51790214482_31c994dd38_b.jpg)
+![Humboldt Summit View {768x502}](https://live.staticflickr.com/65535/51790214482_31c994dd38_b.jpg)
 
 _A wider view of the Crestones from the summit of Humboldt Peak._
 

--- a/blog/hike/winter-white-whale.md
+++ b/blog/hike/winter-white-whale.md
@@ -23,13 +23,13 @@ The next morning, everyone was quick to wake and we set out for the 2WD parking 
 
 The first couple of miles snowshoeing the road before the Rainbow Trail turn were uneventful. I think we were all eager for the first sign of alpenglow and hoping to position ourselves for a killer view before it happened. As we gained the Rainbow Trail ridge and began our bushwhack up the east ridge, light hit our backs and warmed the scene around us. Navigating through the trees, the snow glistened like it had been coated with glitter, while the fresh powder made it seem like no one had broken trail in several months.
 
-![First Light {768x576}](https://live.staticflickr.com/65535/51732591448_cbc12127da_k.jpg)
+![First Light](https://live.staticflickr.com/65535/51732591448_cbc12127da_k.jpg)
 
 _First light seen along Humboldt's east ridge approach._
 
 About 3.5 miles in, we realized we were all working especially hard but not seeming to gain quite as much elevation as is to be expected at this point along the trail. It seemed like we were moving straight, not up. Our group had begun to drift, with two leading and two holding up the rear, just barely out of audible communication distance. We later learned that the leading group had unintentional followed some SAR tracks off route, but we were all determined to get up this thing so we continued to trudge even after we realized we had made a mistake.
 
-![The Moonset {768x576}](https://live.staticflickr.com/65535/51732583708_ed244b2cf5_k.jpg)
+![The Moonset](https://live.staticflickr.com/65535/51732583708_ed244b2cf5_k.jpg)
 
 _The moonset, seen right around first light._
 

--- a/blog/thoughts/2021.md
+++ b/blog/thoughts/2021.md
@@ -10,7 +10,7 @@ At the beginning of 2021, I hadn't really considered what kind of goal I could s
 
 Instead, I set my sights on a hard statistic. Elevation seemed like it would be fun to target if not only because it sounded a little tougher to plan than distance. After looking at my achievements from the year prior, I settled on a goal that would also be a tribute to the year we had just entered: 202.1k’ (202,100 feet) of gain. This was 4x what I was able to climb the year prior. I knew it would take some effort, but it felt attainable.
 
-![grizzly-sunrise](https://live.staticflickr.com/65535/51792878161_645bf2d9db_b.jpg)
+![Sunrise over Loveland Pass {768x417}](https://live.staticflickr.com/65535/51792878161_645bf2d9db_b.jpg)
 
 _A snowy June sunrise seen from the saddle between "Cupid" Peak and Mount Sniktau._
 
@@ -22,7 +22,7 @@ I wound up pretty far ahead of schedule at the very beginning of the year only t
 
 By April, I was beyond my quarterly goal and I stopped thinking about elevation first and foremost. At this point, I had built up stamina to more confidently pursue larger goals alone and I wasn't worried about meeting my monthly minimum. Throughout the rest of the year I battled a genetic setback in the form of an accessory navicular (a.k.a. extra bone in my foot), and only then did I find myself nervously looking at the elevation I had planned to gain through the rest of the year.
 
-![hiking Capitol Creek](https://live.staticflickr.com/65535/51847144977_c42bf68c93_b.jpg)
+![Hiking Capitol Creek {768x469}](https://live.staticflickr.com/65535/51847144977_c42bf68c93_b.jpg)
 
 _Hiking in the Maroon Bells-Snowmass Wilderness, Capitol Peak in sight._
 
@@ -34,7 +34,7 @@ Trying not to put too much pressure on my injury as I weighed my more permanent 
 
 ## Goal Achieved
 
-![west-maroon](https://raw.githubusercontent.com/kale-stew/climb-log/main/public/photos/west_maroon.jpeg)
+![Descending West Maroon Pass {768x496}](https://raw.githubusercontent.com/kale-stew/climb-log/main/public/photos/west_maroon.jpeg)
 
 _Hiking down from West Maroon Pass back to our campsite in October 2021._
 

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -1,0 +1,34 @@
+import Image from 'next/image'
+import ReactMarkdown from 'react-markdown'
+
+export default function BlogMarkdown({ markdown }) {
+  const MarkdownComponents = {
+    p: (paragraph) => {
+      const { node } = paragraph
+
+      if (node.children[0].tagName === 'img') {
+        const image = node.children[0]
+        const alt = image.properties.alt?.replace(/ *\{[^)]*\} */g, '')
+        const isPriority = image.properties.alt?.toLowerCase().includes('{priority}')
+        const metaWidth = image.properties.alt.match(/{([^}]+)x/)
+        const metaHeight = image.properties.alt.match(/x([^}]+)}/)
+        const width = metaWidth ? metaWidth[1] : '768'
+        const height = metaHeight ? metaHeight[1] : '432'
+
+        return (
+          <Image
+            src={image.properties.src}
+            width={width}
+            height={height}
+            className="postImg"
+            alt={alt}
+            priority={isPriority}
+          />
+        )
+      }
+      return <p>{paragraph.children}</p>
+    },
+  }
+
+  return <ReactMarkdown components={MarkdownComponents}>{markdown}</ReactMarkdown>
+}

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -13,7 +13,7 @@ export default function BlogMarkdown({ markdown }) {
         const metaWidth = image.properties.alt.match(/{([^}]+)x/)
         const metaHeight = image.properties.alt.match(/x([^}]+)}/)
         const width = metaWidth ? metaWidth[1] : '768'
-        const height = metaHeight ? metaHeight[1] : '432'
+        const height = metaHeight ? metaHeight[1] : '576'
 
         return (
           <Image

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,11 @@ module.exports = {
     NOTION_PHOTO_DATABASE_ID: process.env.NOTION_PHOTO_DATABASE_ID,
   },
   images: {
-    domains: ['s3.us-west-2.amazonaws.com', 'live.staticflickr.com'],
+    domains: [
+      's3.us-west-2.amazonaws.com',
+      'live.staticflickr.com',
+      'raw.githubusercontent.com',
+    ],
   },
   async redirects() {
     return [

--- a/pages/[category]/[id].js
+++ b/pages/[category]/[id].js
@@ -1,7 +1,7 @@
+import BlogMarkdown from '../../components/Markdown'
 import Category from '../../components/Category'
 import FormattedDate from '../../components/Date'
 import Layout from '../../components/Layout'
-import ReactMarkdown from 'react-markdown'
 import ShareButton from '../../components/ShareButton'
 import { PREVIEW_CARD_COLORS } from '../../utils/constants'
 import { buildNavigation } from '../../components/BlogNavigation'
@@ -24,7 +24,7 @@ const Post = ({ postData, postIds }) => (
         />
         <Category category={postData.category} pushToRouter={true} />
       </div>
-      <ReactMarkdown>{postData.content}</ReactMarkdown>
+      <BlogMarkdown markdown={postData.content} />
     </article>
     <div className={styles.socialButtons}>
       <ShareButton type="twitter" data={postData} />


### PR DESCRIPTION
- Use next/image to display blog post photos. Default dimensions are set to iPhone scale (W: `768`, H: `576`)
- Added photos to older posts, updated captions across the board.
- Allows us to handle metadata in markdown image captions: `![Image Caption {WxH}]()`