### PR TITLE
refactor: codex compliance — type safety, validation, sync correctness

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -4,11 +4,7 @@ import react from '@astrojs/react'
 
 export default defineConfig({
   output: 'server',
-  adapter: cloudflare({
-    platformProxy: {
-      enabled: true,
-    },
-  }),
+  adapter: cloudflare(),
   integrations: [react()],
   vite: {
     resolve: {

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!**/dist", "!**/.astro", "!**/public", "!**/*.astro"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "asNeeded"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -72,7 +72,7 @@ function escapeSQL(value: unknown): string {
   return `'${String(value).replace(/'/g, "''")}'`
 }
 
-function generateInsertSQL<T extends Record<string, unknown>>(
+function generateInsertSQL<T extends object>(
   table: string,
   data: T[],
   columns: (keyof T)[]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "migrate:schema:remote": "node scripts/migrate/merge-photos-schema.mjs --remote",
     "migrate:r2": "node scripts/migrate/r2-sync.mjs",
     "format": "prettier --write .",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "typecheck": "astro check && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -44,6 +46,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.16",
     "@cloudflare/workers-types": "^4.20250515.0",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,12 @@
     "migrate:schema:remote": "node scripts/migrate/merge-photos-schema.mjs --remote",
     "migrate:r2": "node scripts/migrate/r2-sync.mjs",
     "format": "prettier --write .",
-    "typecheck": "astro check && tsc --noEmit"
+    "typecheck": "astro check && tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@astrojs/check": "^0.9.9",
     "@astrojs/cloudflare": "^13.2.0",
     "@astrojs/react": "^4.3.0",
     "@hono/zod-validator": "^0.8.0",
@@ -47,6 +50,7 @@
     "prettier": "^3.5.3",
     "tsx": "^4.22.3",
     "typescript": "^5.9.3",
+    "vitest": "^3.2.6",
     "wrangler": "^4.94.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^13.2.0",
     "@astrojs/react": "^4.3.0",
+    "@hono/zod-validator": "^0.8.0",
     "@notionhq/client": "^2.3.0",
     "astro": "^6.3.7",
     "date-fns": "^4.1.0",
@@ -36,7 +37,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^2.15.3",
-    "workers-og": "^0.0.27"
+    "workers-og": "^0.0.27",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250515.0",

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -1,0 +1,117 @@
+/**
+ * Backfill photo embeddings to Vectorize index
+ * 
+ * Run with: npx tsx scripts/backfill-embeddings.ts
+ * 
+ * Prerequisites:
+ *   1. Run scripts/setup-vectorize.sh first
+ *   2. Ensure D1 database has photos
+ *   3. Configure wrangler.jsonc with Vectorize binding
+ */
+
+const BATCH_SIZE = 100;
+
+interface Photo {
+  id: string;
+  title: string | null;
+  caption: string | null;
+  search_tags: string | null;
+  ai_caption: string | null;
+  exclude: number;
+}
+
+interface Env {
+  DB: D1Database;
+  AI: Ai;
+  VECTORIZE: VectorizeIndex;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname !== '/backfill') {
+      return new Response('Use /backfill to run the embeddings backfill', { status: 200 });
+    }
+
+    try {
+      const result = await backfillEmbeddings(env.DB, env.AI, env.VECTORIZE);
+      return new Response(JSON.stringify(result, null, 2), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+};
+
+async function backfillEmbeddings(
+  db: D1Database, 
+  ai: Ai, 
+  vectorize: VectorizeIndex
+): Promise<{ processed: number; errors: string[] }> {
+  // Validate index exists before backfilling
+  try {
+    await vectorize.describe();
+  } catch (error) {
+    throw new Error(
+      'Vectorize index not found. Run scripts/setup-vectorize.sh first!'
+    );
+  }
+
+  const photos = await db.prepare(
+    'SELECT id, title, caption, search_tags, ai_caption, exclude FROM photos WHERE exclude = 0'
+  ).all<Photo>();
+  
+  console.log(`Found ${photos.results.length} photos to embed`);
+
+  const errors: string[] = [];
+  let processed = 0;
+
+  for (let i = 0; i < photos.results.length; i += BATCH_SIZE) {
+    const batch = photos.results.slice(i, i + BATCH_SIZE);
+    
+    try {
+      // Build text for each photo by combining available fields
+      const texts = batch.map(p => 
+        [p.title, p.caption, p.search_tags, p.ai_caption]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || 'photo'  // Fallback if no text available
+      );
+      
+      // Generate embeddings using BGE model.
+      // The runtime shape is { data: number[][] }; validated below before use.
+      const response = await ai.run('@cf/baai/bge-base-en-v1.5', { text: texts }) as { data: number[][] };
+      
+      if (!response.data || response.data.length !== batch.length) {
+        throw new Error(`Embedding count mismatch: got ${response.data?.length}, expected ${batch.length}`);
+      }
+      
+      // Build vectors for upsert
+      const vectors = batch.map((photo, j) => ({
+        id: photo.id,
+        values: response.data[j],
+        metadata: { photo_id: photo.id }
+      }));
+
+      await vectorize.upsert(vectors);
+      
+      processed += batch.length;
+      console.log(`Processed ${processed}/${photos.results.length} photos`);
+      
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      errors.push(`Batch starting at ${i}: ${message}`);
+      console.error(`Error processing batch at ${i}:`, error);
+    }
+  }
+  
+  console.log(`Backfill complete! Processed: ${processed}, Errors: ${errors.length}`);
+  
+  return { processed, errors };
+}

--- a/src/components/ClimbTable.tsx
+++ b/src/components/ClimbTable.tsx
@@ -35,12 +35,12 @@ export default function ClimbTable({ climbs, pageSize: initialPageSize = 50 }: C
 
   // Get unique areas and states for filters
   const areas = useMemo(() => {
-    const set = new Set(climbs.map(c => c.area).filter(Boolean))
+    const set = new Set(climbs.map(c => c.area).filter((a): a is string => Boolean(a)))
     return Array.from(set).sort()
   }, [climbs])
 
   const states = useMemo(() => {
-    const set = new Set(climbs.map(c => c.state).filter(Boolean))
+    const set = new Set(climbs.map(c => c.state).filter((s): s is string => Boolean(s)))
     return Array.from(set).sort()
   }, [climbs])
 
@@ -94,12 +94,6 @@ export default function ClimbTable({ climbs, pageSize: initialPageSize = 50 }: C
     const start = (currentPage - 1) * pageSize
     return filteredClimbs.slice(start, start + pageSize)
   }, [filteredClimbs, currentPage, pageSize])
-
-  // Reset to page 1 when filters change
-  const handleFilterChange = (setter: (val: string) => void) => (val: string) => {
-    setter(val)
-    setCurrentPage(1)
-  }
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,5 @@
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
+import { z } from 'astro/zod'
 import { glob } from 'astro/loaders'
 
 const blog = defineCollection({

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -13,11 +13,17 @@ export interface CloudflareEnv {
   ALLOWED_WIDTHS: string
 }
 
-// Type the `env` export from `cloudflare:workers`
-declare module 'cloudflare:workers' {
-  export const env: CloudflareEnv
-}
+declare global {
+  /**
+   * Populate the `Cloudflare.Env` interface that `cloudflare:workers` uses to
+   * type its `env` export. Declaration merging adds our bindings, so
+   * `import { env } from 'cloudflare:workers'` is fully typed.
+   */
+  namespace Cloudflare {
+    interface Env extends CloudflareEnv {}
+  }
 
-declare namespace App {
-  interface Locals extends import('@astrojs/cloudflare').Runtime<CloudflareEnv> {}
+  namespace App {
+    interface Locals extends import('@astrojs/cloudflare').Runtime<CloudflareEnv> {}
+  }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,7 +6,7 @@
  * Cloudflare Workers environment bindings.
  * These match the bindings defined in wrangler.jsonc.
  */
-interface CloudflareEnv {
+export interface CloudflareEnv {
   DB: D1Database
   R2_IMAGES: R2Bucket
   IMAGES: ImagesBinding
@@ -15,8 +15,7 @@ interface CloudflareEnv {
 
 // Type the `env` export from `cloudflare:workers`
 declare module 'cloudflare:workers' {
-  const env: CloudflareEnv
-  export { env }
+  export const env: CloudflareEnv
 }
 
 declare namespace App {

--- a/src/lib/fetch-with-timeout.ts
+++ b/src/lib/fetch-with-timeout.ts
@@ -1,0 +1,77 @@
+/**
+ * Fetch wrapper with timeout support.
+ * 
+ * Workers have a 30-second CPU time limit, but external requests can hang
+ * indefinitely without explicit timeouts. This utility ensures all external
+ * calls have bounded execution time.
+ */
+
+/** Default timeout for external API calls (10 seconds) */
+export const DEFAULT_TIMEOUT_MS = 10_000
+
+/** Extended timeout for image downloads (30 seconds) */
+export const IMAGE_TIMEOUT_MS = 30_000
+
+/**
+ * Error thrown when a fetch request times out.
+ */
+export class FetchTimeoutError extends Error {
+  constructor(url: string, timeoutMs: number) {
+    super(`Request to ${url} timed out after ${timeoutMs}ms`)
+    this.name = 'FetchTimeoutError'
+  }
+}
+
+/**
+ * Fetch with an AbortSignal timeout.
+ * 
+ * @param url - The URL to fetch
+ * @param options - Standard fetch options
+ * @param timeoutMs - Timeout in milliseconds (default: 10s)
+ * @returns The fetch Response
+ * @throws FetchTimeoutError if the request times out
+ * 
+ * @example
+ * ```ts
+ * const res = await fetchWithTimeout('https://api.notion.com/v1/databases/...', {
+ *   headers: { 'Authorization': `Bearer ${token}` }
+ * }, 15_000)
+ * ```
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    })
+    return response
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new FetchTimeoutError(url, timeoutMs)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Fetch an image with extended timeout.
+ * 
+ * @param url - The image URL to fetch
+ * @param timeoutMs - Timeout in milliseconds (default: 30s)
+ * @returns The fetch Response
+ */
+export async function fetchImage(
+  url: string,
+  timeoutMs: number = IMAGE_TIMEOUT_MS
+): Promise<Response> {
+  return fetchWithTimeout(url, {}, timeoutMs)
+}

--- a/src/lib/notion-helpers.ts
+++ b/src/lib/notion-helpers.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure helpers for parsing Notion data during sync.
+ *
+ * These functions have no Cloudflare/Workers dependencies so they can be
+ * imported by both the cron sync (`src/pages/api/cron.ts`) and unit tests.
+ */
+
+/**
+ * Extract a typed property value from a Notion page.
+ */
+export function getNotionProp(
+  page: Record<string, unknown>,
+  name: string,
+  type: string
+): unknown {
+  const properties = page.properties as Record<string, Record<string, unknown>> | undefined
+  if (!properties) return null
+
+  const prop = properties[name]
+  if (!prop) return null
+
+  switch (type) {
+    case 'title': {
+      const titleArray = prop.title as Array<{ plain_text?: string }> | undefined
+      return titleArray?.[0]?.plain_text || null
+    }
+    case 'rich_text': {
+      const textArray = prop.rich_text as Array<{ plain_text?: string }> | undefined
+      return textArray?.[0]?.plain_text || null
+    }
+    case 'number':
+      return prop.number ?? null
+    case 'date': {
+      const dateObj = prop.date as { start?: string } | null
+      return dateObj?.start || null
+    }
+    case 'select': {
+      const selectObj = prop.select as { name?: string } | null
+      return selectObj?.name || null
+    }
+    case 'multi_select': {
+      const multiSelect = prop.multi_select as Array<{ name?: string }> | undefined
+      return multiSelect?.map(s => s.name).filter(Boolean) || []
+    }
+    case 'url':
+      return prop.url || null
+    case 'checkbox':
+      return prop.checkbox ?? false
+    case 'files': {
+      const files = prop.files as
+        | Array<{ file?: { url?: string }; external?: { url?: string } }>
+        | undefined
+      return files?.[0]?.file?.url || files?.[0]?.external?.url || null
+    }
+    default:
+      return null
+  }
+}
+
+/**
+ * Parse `area_fallback` into `area` and `state`.
+ *
+ * Supported formats:
+ * - "Area Name, State"
+ * - "Area Name - State"
+ * - "Area Name- State"
+ *
+ * Internal hyphens in area names (e.g. "Bridger-Teton") are preserved: only a
+ * dash that is adjacent to whitespace is treated as the area/state separator.
+ */
+export function parseAreaFallback(
+  areaFallback: string | null
+): { area: string | null; state: string | null } {
+  if (!areaFallback) {
+    return { area: null, state: null }
+  }
+
+  let area: string | null = null
+  let state: string | null = null
+
+  if (areaFallback.includes(',')) {
+    const parts = areaFallback.split(',').map(s => s.trim())
+    area = parts[0] || null
+    state = normalizeStateName(parts[1]) || null
+  } else if (/\s-|-\s/.test(areaFallback)) {
+    // Split on a whitespace-adjacent dash so "Bridger-Teton - Wyoming"
+    // yields area="Bridger-Teton", state="Wyoming".
+    const parts = areaFallback.split(/\s*-\s+|\s+-\s*/).map(s => s.trim())
+    area = parts[0] || null
+    state = normalizeStateName(parts[1]) || null
+  } else {
+    area = areaFallback
+  }
+
+  // Normalize internal spacing around hyphens (e.g. "Bridger - Teton" -> "Bridger-Teton").
+  if (area) {
+    area = area.replace(/\s*-\s*/g, '-').trim()
+  }
+
+  return { area, state }
+}
+
+/**
+ * Parse a comma-separated tag string into a normalized, deduplicated,
+ * alphabetically sorted comma-separated string. Returns null when empty.
+ */
+export function parseTags(tagsRaw: string | null): string | null {
+  if (!tagsRaw) return null
+
+  const tags = tagsRaw
+    .split(',')
+    .map(t => t.trim().toLowerCase())
+    .filter(t => t.length > 0)
+  const uniqueTags = Array.from(new Set(tags)).sort()
+  return uniqueTags.length > 0 ? uniqueTags.join(', ') : null
+}
+
+/**
+ * Normalize state names/abbreviations to full state names.
+ * Unknown values pass through trimmed.
+ */
+export function normalizeStateName(state: string | null | undefined): string | null {
+  if (!state) return null
+
+  const stateMap: Record<string, string> = {
+    AZ: 'Arizona',
+    CA: 'California',
+    CO: 'Colorado',
+    ID: 'Idaho',
+    MT: 'Montana',
+    NM: 'New Mexico',
+    NV: 'Nevada',
+    OR: 'Oregon',
+    UT: 'Utah',
+    WA: 'Washington',
+    WY: 'Wyoming',
+    Alaska: 'Alaska',
+    'Washington State': 'Washington',
+  }
+
+  const trimmed = state.trim()
+  return stateMap[trimmed] || trimmed
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -47,58 +47,27 @@ export const photoListQuerySchema = z.object({
 
 export type PhotoListQuery = z.infer<typeof photoListQuerySchema>
 
-// ============ Cron/Sync Schemas ============
-
-/** Schema for manual cron trigger */
-export const cronTriggerSchema = z.object({
-  secret: z.string().min(1, 'Secret is required'),
-})
-
 // ============ Utility ============
 
-/**
- * Parse and validate input against a schema.
- * Returns the validated data or throws a validation error.
- * 
- * @param schema - Zod schema to validate against
- * @param data - Data to validate
- * @returns Validated and typed data
- */
-export function parseOrThrow<T>(schema: z.ZodSchema<T>, data: unknown): T {
-  return schema.parse(data)
-}
-
-/**
- * Safely parse input against a schema.
- * Returns a result object with success/error state.
- * 
- * @param schema - Zod schema to validate against
- * @param data - Data to validate
- * @returns SafeParseReturnType with data or error
- */
-export function safeParse<T>(schema: z.ZodSchema<T>, data: unknown) {
-  return schema.safeParse(data)
-}
-
-interface ZodIssue {
-  path: readonly (string | number)[]
+interface ZodIssueLike {
+  path: readonly PropertyKey[]
   message: string
 }
 
 interface ZodErrorLike {
-  issues: readonly ZodIssue[]
+  issues: readonly ZodIssueLike[]
 }
 
 /**
  * Format Zod errors into a user-friendly message.
- * Works with both Zod v3 and v4 error types.
- * 
+ * Typed structurally so it works across Zod v3/v4 error shapes.
+ *
  * @param error - Zod error object (any version)
  * @returns Formatted error message
  */
 export function formatZodError(error: ZodErrorLike): string {
   return error.issues.map(issue => {
-    const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+    const path = issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : ''
     return `${path}${issue.message}`
   }).join('; ')
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,0 +1,104 @@
+/**
+ * Zod schemas for API input validation.
+ * 
+ * These schemas validate incoming request bodies and query parameters
+ * to ensure type safety and provide clear error messages.
+ */
+
+import { z } from 'zod'
+
+// ============ Photo Schemas ============
+
+/** Schema for updating photo metadata */
+export const updatePhotoSchema = z.object({
+  title: z.string().max(500).nullable().optional(),
+  location: z.string().max(500).nullable().optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format').nullable().optional(),
+  tags: z.string().max(2000).nullable().optional(),
+  site: z.enum(['climb-log', 'kylieis-online', 'both']).optional(),
+  exclude: z.boolean().optional(),
+  caption: z.string().max(2000).nullable().optional(),
+}).strict()
+
+export type UpdatePhotoInput = z.infer<typeof updatePhotoSchema>
+
+/** Schema for resize request */
+export const resizePhotoSchema = z.object({
+  photoId: z.string().min(1, 'photoId is required'),
+  width: z.coerce.number().int().min(1).max(2048),
+})
+
+export type ResizePhotoInput = z.infer<typeof resizePhotoSchema>
+
+/** Schema for extract-colors request */
+export const extractColorsSchema = z.object({
+  photoId: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+})
+
+export type ExtractColorsInput = z.infer<typeof extractColorsSchema>
+
+/** Schema for photo list query parameters */
+export const photoListQuerySchema = z.object({
+  site: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export type PhotoListQuery = z.infer<typeof photoListQuerySchema>
+
+// ============ Cron/Sync Schemas ============
+
+/** Schema for manual cron trigger */
+export const cronTriggerSchema = z.object({
+  secret: z.string().min(1, 'Secret is required'),
+})
+
+// ============ Utility ============
+
+/**
+ * Parse and validate input against a schema.
+ * Returns the validated data or throws a validation error.
+ * 
+ * @param schema - Zod schema to validate against
+ * @param data - Data to validate
+ * @returns Validated and typed data
+ */
+export function parseOrThrow<T>(schema: z.ZodSchema<T>, data: unknown): T {
+  return schema.parse(data)
+}
+
+/**
+ * Safely parse input against a schema.
+ * Returns a result object with success/error state.
+ * 
+ * @param schema - Zod schema to validate against
+ * @param data - Data to validate
+ * @returns SafeParseReturnType with data or error
+ */
+export function safeParse<T>(schema: z.ZodSchema<T>, data: unknown) {
+  return schema.safeParse(data)
+}
+
+interface ZodIssue {
+  path: readonly (string | number)[]
+  message: string
+}
+
+interface ZodErrorLike {
+  issues: readonly ZodIssue[]
+}
+
+/**
+ * Format Zod errors into a user-friendly message.
+ * Works with both Zod v3 and v4 error types.
+ * 
+ * @param error - Zod error object (any version)
+ * @returns Formatted error message
+ */
+export function formatZodError(error: ZodErrorLike): string {
+  return error.issues.map(issue => {
+    const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+    return `${path}${issue.message}`
+  }).join('; ')
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared type definitions for the climb-log application.
+ * 
+ * These interfaces match the D1 database schema defined in migrations/.
+ */
+
+/** Climb record from the `climbs` table */
+export interface Climb {
+  id: string
+  notion_id: string | null
+  date: string | null
+  title: string | null
+  slug: string | null
+  preview_img_url: string | null
+  distance: number | null
+  gain: number | null
+  max_elevation: number | null
+  moving_time: number | null
+  area: string | null
+  state: string | null
+  strava: string | null
+  alltrails: string | null
+  published: number
+  created_at: string
+  updated_at: string
+}
+
+/** Peak record from the `peaks` table */
+export interface Peak {
+  id: string
+  notion_id: string | null
+  name: string | null
+  title: string | null // legacy column
+  elevation: number
+  prominence: number | null
+  range: string | null
+  first_completed: string | null
+  attempts: number | null
+  list_class: string | null
+  img: string | null
+  rank: number | null
+  created_at: string
+  updated_at: string
+}
+
+/** Gear record from the `gear` table */
+export interface Gear {
+  id: string
+  notion_id: string | null
+  name: string | null
+  title: string | null // legacy column
+  brand: string | null
+  category: string | null
+  weight_oz: number | null
+  price: number | null
+  rating: number | null
+  status: string | null
+  notes: string | null
+  url: string | null
+  image_url: string | null
+  acquired_on: string | null
+  retired_on: string | null
+  color: string | null
+  more_info: string | null
+  pack_list: string | null
+  product_str: string | null
+  retailer: string | null
+  created_at: string
+  updated_at: string
+}
+
+/** Photo record from the `photos` table */
+export interface Photo {
+  id: string
+  short_id: string | null
+  notion_id: string | null
+  r2_key: string | null
+  src: string | null
+  title: string | null
+  caption: string | null
+  location: string | null
+  area: string | null
+  state: string | null
+  date: string | null
+  width: number | null
+  height: number | null
+  blurhash: string | null
+  format: string
+  size_bytes: number | null
+  site: string
+  source: string | null
+  search_tags: string | null
+  tags: string | null
+  exclude: number
+  flickr_id: string | null
+  accent_color: string | null
+  source_url: string | null
+  created_at: string
+  updated_at: string
+}
+
+/** Blog post record from the `blog_posts` table */
+export interface BlogPost {
+  id: string
+  internal_rowid: number | null
+  title: string
+  category: string
+  content_text: string | null
+  tags: string | null
+  date: string | null
+  slug: string | null
+}
+
+/** Post record from the legacy `posts` table */
+export interface Post {
+  id: string
+  title: string
+  category: string
+  date: string | null
+  preview: string | null
+  preview_img_url: string | null
+  created_at: string
+  updated_at: string
+}
+
+/** Sync log record from the `sync_log` table */
+export interface SyncLog {
+  id: number
+  sync_type: string
+  status: string
+  records_synced: number
+  error_message: string | null
+  started_at: string
+  completed_at: string | null
+}
+
+/** Subset of Climb fields used in the climbs list view */
+export interface ClimbListItem {
+  id: string
+  date: string | null
+  title: string | null
+  slug: string | null
+  preview_img_url: string | null
+  distance: number | null
+  gain: number | null
+  area: string | null
+  state: string | null
+  strava: string | null
+}
+
+/** Result type for Notion sync operations */
+export interface SyncResult {
+  table: string
+  inserted: number
+  updated: number
+  errors: string[]
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -60,9 +60,8 @@ const interviews = [
                 src={`${interview.embedHref}?utm_source=generator&theme=0`}
                 width="100%"
                 height="80"
-                frameborder="0"
                 allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                style="border-radius: 12px; margin-top: 1rem;"
+                style="border: 0; border-radius: 12px; margin-top: 1rem;"
               />
             </li>
           ))}

--- a/src/pages/admin/climbs.astro
+++ b/src/pages/admin/climbs.astro
@@ -32,8 +32,8 @@ if (DB) {
   ).all()
   recentAssignments = assignmentsResult.results || []
 
-  const totalResult = await DB.prepare('SELECT COUNT(*) as total FROM climbs').first()
-  const missingResult = await DB.prepare(`SELECT COUNT(*) as missing FROM climbs WHERE preview_img_url IS NULL OR preview_img_url = ''`).first()
+  const totalResult = await DB.prepare('SELECT COUNT(*) as total FROM climbs').first<{ total: number }>()
+  const missingResult = await DB.prepare(`SELECT COUNT(*) as missing FROM climbs WHERE preview_img_url IS NULL OR preview_img_url = ''`).first<{ missing: number }>()
   stats = {
     totalClimbs: totalResult?.total || 0,
     missingPhotos: missingResult?.missing || 0,
@@ -119,26 +119,24 @@ function formatDate(dateStr: string | null) {
   </div>
 
   <script>
-    let selectedPhotoUrl = null;
-    let selectedPhotoEl = null;
+    let selectedPhotoUrl: string | null = null;
 
-    document.querySelectorAll('.photo-thumb').forEach(el => {
+    document.querySelectorAll<HTMLElement>('.photo-thumb').forEach(el => {
       el.addEventListener('click', () => {
         document.querySelectorAll('.photo-thumb').forEach(p => p.classList.remove('selected'));
         el.classList.add('selected');
-        selectedPhotoUrl = el.dataset.photoUrl;
-        selectedPhotoEl = el;
+        selectedPhotoUrl = el.dataset.photoUrl ?? null;
       });
     });
 
-    document.querySelectorAll('.climb-item').forEach(el => {
+    document.querySelectorAll<HTMLElement>('.climb-item').forEach(el => {
       el.addEventListener('click', async () => {
         if (!selectedPhotoUrl) {
           alert('Select a photo first, then click a climb to assign it.');
           return;
         }
 
-        const climbId = el.dataset.climbId;
+        const climbId = el.dataset.climbId ?? '';
         const climbTitle = el.querySelector('h3')?.textContent || 'Unknown';
         el.style.opacity = '0.5';
 
@@ -150,11 +148,11 @@ function formatDate(dateStr: string | null) {
           });
 
           if (res.ok) {
-            const data = await res.json();
-            
+            const data = await res.json() as { assignmentId: string };
+
             // Add to audit log
             addAuditItem(data.assignmentId, climbId, climbTitle, selectedPhotoUrl);
-            
+
             // Remove from needs-photo list
             el.style.transition = 'all 0.3s ease';
             el.style.opacity = '0';
@@ -166,14 +164,15 @@ function formatDate(dateStr: string | null) {
           }
         } catch (err) {
           el.style.opacity = '1';
-          alert('Error: ' + err.message);
+          alert('Error: ' + (err instanceof Error ? err.message : String(err)));
         }
       });
     });
 
     // Add a new item to the audit list
-    function addAuditItem(assignmentId, climbId, climbTitle, photoUrl) {
+    function addAuditItem(assignmentId: string, climbId: string, climbTitle: string, photoUrl: string) {
       const auditList = document.getElementById('audit-list');
+      if (!auditList) return;
       const emptyState = auditList.querySelector('.empty-state');
       if (emptyState) emptyState.remove();
 
@@ -189,23 +188,24 @@ function formatDate(dateStr: string | null) {
         </div>
         <button class="undo-btn" title="Undo this assignment">Undo</button>
       `;
-      
+
       // Add to top of list
       auditList.insertBefore(item, auditList.firstChild);
-      
+
       // Bind undo handler
-      item.querySelector('.undo-btn').addEventListener('click', handleUndo);
+      item.querySelector('.undo-btn')?.addEventListener('click', handleUndo);
     }
 
     // Handle undo button clicks
-    async function handleUndo(e) {
-      const item = e.target.closest('.audit-item');
+    async function handleUndo(e: Event) {
+      const button = e.currentTarget as HTMLButtonElement;
+      const item = button.closest<HTMLElement>('.audit-item');
+      if (!item) return;
       const assignmentId = item.dataset.assignmentId;
-      const climbId = item.dataset.climbId;
-      
+
       item.style.opacity = '0.5';
-      e.target.disabled = true;
-      e.target.textContent = '...';
+      button.disabled = true;
+      button.textContent = '...';
 
       try {
         const res = await fetch('/api/admin/undo-photo', {
@@ -223,25 +223,25 @@ function formatDate(dateStr: string | null) {
             item.remove();
             // Show empty state if no more items
             const auditList = document.getElementById('audit-list');
-            if (!auditList.querySelector('.audit-item')) {
+            if (auditList && !auditList.querySelector('.audit-item')) {
               auditList.innerHTML = '<p class="empty-state">No assignments yet</p>';
             }
           }, 300);
-          
+
           // Optionally refresh the page to show the climb back in the list
           // For now, just show a brief notification
-          console.log('Assignment undone for climb:', climbId);
+          console.log('Assignment undone for climb:', item.dataset.climbId);
         } else {
           item.style.opacity = '1';
-          e.target.disabled = false;
-          e.target.textContent = 'Undo';
+          button.disabled = false;
+          button.textContent = 'Undo';
           alert('Failed to undo assignment');
         }
       } catch (err) {
         item.style.opacity = '1';
-        e.target.disabled = false;
-        e.target.textContent = 'Undo';
-        alert('Error: ' + err.message);
+        button.disabled = false;
+        button.textContent = 'Undo';
+        alert('Error: ' + (err instanceof Error ? err.message : String(err)));
       }
     }
 

--- a/src/pages/admin/photos/[...path].ts
+++ b/src/pages/admin/photos/[...path].ts
@@ -7,9 +7,9 @@ export const prerender = false
 // Handles all /admin/photos/* routes (admin UI)
 export const GET: APIRoute = async ({ request }) => {
   const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
+    DB: env.DB,
+    R2_IMAGES: env.R2_IMAGES,
+    IMAGES: env.IMAGES,
   })
   return app.fetch(request)
 }

--- a/src/pages/api/admin/photos/[...path].ts
+++ b/src/pages/api/admin/photos/[...path].ts
@@ -5,15 +5,19 @@ import { createPhotosApp } from '../../../../../utils/photos-api'
 export const prerender = false
 
 /**
- * Create the photos Hono app with bindings from the Cloudflare environment.
- * Factored out to avoid duplication across HTTP methods.
+ * Build the photos Hono app once per isolate and reuse it across requests.
+ * Lazily initialized so the Cloudflare `env` binding is available on first use.
  */
+let photosApp: ReturnType<typeof createPhotosApp> | undefined
 function getPhotosApp() {
-  return createPhotosApp({
-    DB: env.DB,
-    R2_IMAGES: env.R2_IMAGES,
-    IMAGES: env.IMAGES,
-  })
+  if (!photosApp) {
+    photosApp = createPhotosApp({
+      DB: env.DB,
+      R2_IMAGES: env.R2_IMAGES,
+      IMAGES: env.IMAGES,
+    })
+  }
+  return photosApp
 }
 
 // Handles all /api/admin/photos/* routes

--- a/src/pages/api/admin/photos/[...path].ts
+++ b/src/pages/api/admin/photos/[...path].ts
@@ -4,39 +4,31 @@ import { createPhotosApp } from '../../../../../utils/photos-api'
 
 export const prerender = false
 
+/**
+ * Create the photos Hono app with bindings from the Cloudflare environment.
+ * Factored out to avoid duplication across HTTP methods.
+ */
+function getPhotosApp() {
+  return createPhotosApp({
+    DB: env.DB,
+    R2_IMAGES: env.R2_IMAGES,
+    IMAGES: env.IMAGES,
+  })
+}
+
 // Handles all /api/admin/photos/* routes
 export const GET: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }
 
 export const POST: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }
 
 export const PATCH: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }
 
 export const DELETE: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }

--- a/src/pages/api/cron.ts
+++ b/src/pages/api/cron.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro'
-import { Client, isNotionClientError, APIErrorCode } from '@notionhq/client'
+import { Client, isNotionClientError } from '@notionhq/client'
 import { env } from 'cloudflare:workers'
 import { fetchImage, IMAGE_TIMEOUT_MS, FetchTimeoutError } from '../../lib/fetch-with-timeout'
 import type { SyncResult } from '../../lib/types'

--- a/src/pages/api/cron.ts
+++ b/src/pages/api/cron.ts
@@ -3,6 +3,7 @@ import { Client, isNotionClientError, APIErrorCode } from '@notionhq/client'
 import { env } from 'cloudflare:workers'
 import { fetchImage, IMAGE_TIMEOUT_MS, FetchTimeoutError } from '../../lib/fetch-with-timeout'
 import type { SyncResult } from '../../lib/types'
+import { getNotionProp, parseAreaFallback, parseTags } from '../../lib/notion-helpers'
 
 export const prerender = false
 
@@ -211,48 +212,14 @@ async function getAllPages(notion: Client, databaseId: string): Promise<Array<Re
   return pages
 }
 
-// Helper to extract property values from Notion
-function getNotionProp(page: Record<string, unknown>, name: string, type: string): unknown {
-  const properties = page.properties as Record<string, Record<string, unknown>> | undefined
-  if (!properties) return null
-  
-  const prop = properties[name]
-  if (!prop) return null
-
-  switch (type) {
-    case 'title': {
-      const titleArray = prop.title as Array<{ plain_text?: string }> | undefined
-      return titleArray?.[0]?.plain_text || null
-    }
-    case 'rich_text': {
-      const textArray = prop.rich_text as Array<{ plain_text?: string }> | undefined
-      return textArray?.[0]?.plain_text || null
-    }
-    case 'number':
-      return prop.number ?? null
-    case 'date': {
-      const dateObj = prop.date as { start?: string } | null
-      return dateObj?.start || null
-    }
-    case 'select': {
-      const selectObj = prop.select as { name?: string } | null
-      return selectObj?.name || null
-    }
-    case 'multi_select': {
-      const multiSelect = prop.multi_select as Array<{ name?: string }> | undefined
-      return multiSelect?.map(s => s.name).filter(Boolean) || []
-    }
-    case 'url':
-      return prop.url || null
-    case 'checkbox':
-      return prop.checkbox ?? false
-    case 'files': {
-      const files = prop.files as Array<{ file?: { url?: string }; external?: { url?: string } }> | undefined
-      return files?.[0]?.file?.url || files?.[0]?.external?.url || null
-    }
-    default:
-      return null
-  }
+/**
+ * Check whether a row with the given id already exists in a table.
+ * Used to distinguish inserts from updates when reporting sync counts.
+ * `table` is always a hardcoded literal (never user input), so interpolation is safe.
+ */
+async function rowExists(db: D1Database, table: string, id: string): Promise<boolean> {
+  const row = await db.prepare(`SELECT 1 FROM ${table} WHERE id = ? LIMIT 1`).bind(id).first()
+  return row !== null
 }
 
 async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise<SyncResult> {
@@ -274,6 +241,7 @@ async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise
       const id = pageId.replace(/-/g, '')
       const data = {
         id,
+        notion_id: pageId,
         date: getNotionProp(page, 'Date', 'date') as string | null,
         title: getNotionProp(page, 'Name', 'title') as string | null,
         slug: getNotionProp(page, 'Slug', 'rich_text') as string | null,
@@ -289,10 +257,13 @@ async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise
         published: getNotionProp(page, 'Published', 'checkbox') as boolean,
       }
 
+      const existed = await rowExists(db, 'climbs', id)
+
       await db.prepare(`
-        INSERT INTO climbs (id, date, title, slug, preview_img_url, distance, gain, max_elevation, moving_time, area, state, strava, alltrails, published, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        INSERT INTO climbs (id, notion_id, date, title, slug, preview_img_url, distance, gain, max_elevation, moving_time, area, state, strava, alltrails, published, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
         ON CONFLICT(id) DO UPDATE SET
+          notion_id = excluded.notion_id,
           date = excluded.date,
           title = excluded.title,
           slug = excluded.slug,
@@ -308,12 +279,13 @@ async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise
           published = excluded.published,
           updated_at = datetime('now')
       `).bind(
-        data.id, data.date, data.title, data.slug, data.preview_img_url,
+        data.id, data.notion_id, data.date, data.title, data.slug, data.preview_img_url,
         data.distance, data.gain, data.max_elevation, data.moving_time,
         data.area, data.state, data.strava, data.alltrails, data.published ? 1 : 0
       ).run()
 
-      result.inserted++
+      if (existed) result.updated++
+      else result.inserted++
     } catch (error) {
       const pageId = page.id as string
       result.errors.push(`Climb ${pageId}: ${formatError(error)}`)
@@ -342,6 +314,7 @@ async function syncPeaks(notion: Client, db: D1Database, dbId: string): Promise<
       const id = pageId.replace(/-/g, '')
       const data = {
         id,
+        notion_id: pageId,
         name: getNotionProp(page, 'Name', 'title') as string | null,
         elevation: getNotionProp(page, 'Elevation', 'number') as number | null,
         prominence: getNotionProp(page, 'Prominence', 'number') as number | null,
@@ -351,10 +324,13 @@ async function syncPeaks(notion: Client, db: D1Database, dbId: string): Promise<
         list_class: getNotionProp(page, 'Class', 'select') as string | null,
       }
 
+      const existed = await rowExists(db, 'peaks', id)
+
       await db.prepare(`
-        INSERT INTO peaks (id, name, elevation, prominence, range, first_completed, attempts, list_class, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        INSERT INTO peaks (id, notion_id, name, elevation, prominence, range, first_completed, attempts, list_class, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
         ON CONFLICT(id) DO UPDATE SET
+          notion_id = excluded.notion_id,
           name = excluded.name,
           elevation = excluded.elevation,
           prominence = excluded.prominence,
@@ -364,11 +340,12 @@ async function syncPeaks(notion: Client, db: D1Database, dbId: string): Promise<
           list_class = excluded.list_class,
           updated_at = datetime('now')
       `).bind(
-        data.id, data.name, data.elevation, data.prominence,
+        data.id, data.notion_id, data.name, data.elevation, data.prominence,
         data.range, data.first_completed, data.attempts, data.list_class
       ).run()
 
-      result.inserted++
+      if (existed) result.updated++
+      else result.inserted++
     } catch (error) {
       const pageId = page.id as string
       result.errors.push(`Peak ${pageId}: ${formatError(error)}`)
@@ -397,6 +374,7 @@ async function syncGear(notion: Client, db: D1Database, dbId: string): Promise<S
       const id = pageId.replace(/-/g, '')
       const data = {
         id,
+        notion_id: pageId,
         name: getNotionProp(page, 'Name', 'title') as string | null,
         brand: getNotionProp(page, 'Brand', 'select') as string | null,
         category: getNotionProp(page, 'Category', 'select') as string | null,
@@ -409,10 +387,13 @@ async function syncGear(notion: Client, db: D1Database, dbId: string): Promise<S
         image_url: getNotionProp(page, 'Image', 'files') as string | null,
       }
 
+      const existed = await rowExists(db, 'gear', id)
+
       await db.prepare(`
-        INSERT INTO gear (id, name, brand, category, weight_oz, price, rating, status, notes, url, image_url, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        INSERT INTO gear (id, notion_id, name, brand, category, weight_oz, price, rating, status, notes, url, image_url, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
         ON CONFLICT(id) DO UPDATE SET
+          notion_id = excluded.notion_id,
           name = excluded.name,
           brand = excluded.brand,
           category = excluded.category,
@@ -425,12 +406,13 @@ async function syncGear(notion: Client, db: D1Database, dbId: string): Promise<S
           image_url = excluded.image_url,
           updated_at = datetime('now')
       `).bind(
-        data.id, data.name, data.brand, data.category,
+        data.id, data.notion_id, data.name, data.brand, data.category,
         data.weight_oz, data.price, data.rating, data.status,
         data.notes, data.url, data.image_url
       ).run()
 
-      result.inserted++
+      if (existed) result.updated++
+      else result.inserted++
     } catch (error) {
       const pageId = page.id as string
       result.errors.push(`Gear ${pageId}: ${formatError(error)}`)
@@ -487,6 +469,8 @@ async function syncPhotos(notion: Client, db: D1Database, r2: R2Bucket | undefin
       // Generate deterministic short_id from Notion page ID for clean URLs
       const shortId = await generateShortId(pageId)
 
+      const existed = await rowExists(db, 'photos', id)
+
       await db.prepare(`
         INSERT INTO photos (
           id, notion_id, r2_key, short_id, src, caption, date,
@@ -517,12 +501,15 @@ async function syncPhotos(notion: Client, db: D1Database, r2: R2Bucket | undefin
         format
       ).run()
 
-      // Sync image to R2 so we can serve from our own storage
+      // Sync image to R2 so we can serve from our own storage.
+      // Note: "inserted"/"updated" reflect the D1 row upsert; R2 image sync
+      // failures are logged but do not change these counts.
       if (r2) {
         await syncImageToR2(r2, r2Key, format, url, id)
       }
 
-      result.inserted++
+      if (existed) result.updated++
+      else result.inserted++
     } catch (error) {
       const pageId = page.id as string
       result.errors.push(`Photo ${pageId}: ${formatError(error)}`)
@@ -571,81 +558,4 @@ async function syncImageToR2(
       error: formatError(error) 
     })
   }
-}
-
-/**
- * Parse area_fallback into area and state.
- * Formats: "Area Name, State" or "Area Name- State" or "Area Name - State"
- */
-function parseAreaFallback(areaFallback: string | null): { area: string | null; state: string | null } {
-  if (!areaFallback) {
-    return { area: null, state: null }
-  }
-
-  let area: string | null = null
-  let state: string | null = null
-
-  // Try comma separator first
-  if (areaFallback.includes(',')) {
-    const parts = areaFallback.split(',').map(s => s.trim())
-    area = parts[0] || null
-    state = normalizeStateName(parts[1]) || null
-  }
-  // Try dash separator
-  else if (areaFallback.includes('-')) {
-    const parts = areaFallback.split('-').map(s => s.trim())
-    area = parts[0] || null
-    state = normalizeStateName(parts[1]) || null
-  }
-  // No separator - just area
-  else {
-    area = areaFallback
-  }
-
-  // Clean up area spacing (e.g., "Bridger- Teton" → "Bridger-Teton")
-  if (area) {
-    area = area.replace(/\s*-\s*/g, '-').trim()
-  }
-
-  return { area, state }
-}
-
-/**
- * Parse tags string into normalized, deduplicated, sorted format.
- */
-function parseTags(tagsRaw: string | null): string | null {
-  if (!tagsRaw) return null
-  
-  const tags = tagsRaw
-    .split(',')
-    .map(t => t.trim().toLowerCase())
-    .filter(t => t.length > 0)
-  const uniqueTags = Array.from(new Set(tags)).sort()
-  return uniqueTags.length > 0 ? uniqueTags.join(', ') : null
-}
-
-/**
- * Normalize state names to full names.
- */
-function normalizeStateName(state: string | null | undefined): string | null {
-  if (!state) return null
-  
-  const stateMap: Record<string, string> = {
-    'AZ': 'Arizona',
-    'CA': 'California',
-    'CO': 'Colorado',
-    'ID': 'Idaho',
-    'MT': 'Montana',
-    'NM': 'New Mexico',
-    'NV': 'Nevada',
-    'OR': 'Oregon',
-    'UT': 'Utah',
-    'WA': 'Washington',
-    'WY': 'Wyoming',
-    'Alaska': 'Alaska',
-    'Washington State': 'Washington'
-  }
-  
-  const trimmed = state.trim()
-  return stateMap[trimmed] || trimmed
 }

--- a/src/pages/api/cron.ts
+++ b/src/pages/api/cron.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from 'astro'
-import { Client } from '@notionhq/client'
+import { Client, isNotionClientError, APIErrorCode } from '@notionhq/client'
 import { env } from 'cloudflare:workers'
+import { fetchImage, IMAGE_TIMEOUT_MS, FetchTimeoutError } from '../../lib/fetch-with-timeout'
+import type { SyncResult } from '../../lib/types'
 
 export const prerender = false
 
@@ -12,12 +14,8 @@ const NOTION_DB_IDS = {
   photos: import.meta.env.NOTION_PHOTOS_DB_ID,
 }
 
-interface SyncResult {
-  table: string
-  inserted: number
-  updated: number
-  errors: string[]
-}
+/** Timeout for Notion API operations (15 seconds) */
+const NOTION_TIMEOUT_MS = 15_000
 
 /**
  * Generate a deterministic short URL-safe ID from any string.
@@ -33,6 +31,26 @@ async function generateShortId(input: string): Promise<string> {
   return hashHex.slice(0, 8)
 }
 
+/**
+ * Structured log helper for sync operations.
+ * In production, these logs appear in Workers Logs.
+ */
+function logSync(level: 'info' | 'warn' | 'error', message: string, context?: Record<string, unknown>): void {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...context,
+  }
+  if (level === 'error') {
+    console.error(JSON.stringify(entry))
+  } else if (level === 'warn') {
+    console.warn(JSON.stringify(entry))
+  } else {
+    console.log(JSON.stringify(entry))
+  }
+}
+
 // Manual trigger via GET request with secret
 export const GET: APIRoute = async ({ request }) => {
   const url = new URL(request.url)
@@ -41,7 +59,10 @@ export const GET: APIRoute = async ({ request }) => {
   // Verify secret for manual triggers
   const expectedSecret = import.meta.env.CRON_SECRET
   if (!expectedSecret || secret !== expectedSecret) {
-    return new Response('Unauthorized', { status: 401 })
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { 
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    })
   }
 
   return runSync()
@@ -53,11 +74,12 @@ export const POST: APIRoute = async () => {
 }
 
 async function runSync(): Promise<Response> {
-  const DB = env.DB as D1Database | undefined
-  const R2_IMAGES = env.R2_IMAGES as R2Bucket | undefined
+  const DB = env.DB
+  const R2_IMAGES = env.R2_IMAGES
   const notionToken = import.meta.env.NOTION_TOKEN
 
   if (!DB) {
+    logSync('error', 'D1 not configured')
     return new Response(JSON.stringify({ error: 'D1 not configured' }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }
@@ -65,15 +87,25 @@ async function runSync(): Promise<Response> {
   }
 
   if (!notionToken) {
+    logSync('error', 'Notion token not configured')
     return new Response(JSON.stringify({ error: 'Notion token not configured' }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' }
     })
   }
 
-  const notion = new Client({ auth: notionToken })
+  // Configure Notion client with timeout
+  const notion = new Client({ 
+    auth: notionToken,
+    timeoutMs: NOTION_TIMEOUT_MS,
+  })
+  
   const results: SyncResult[] = []
   const startTime = Date.now()
+
+  logSync('info', 'Starting Notion sync', { 
+    databases: Object.entries(NOTION_DB_IDS).filter(([, v]) => v).map(([k]) => k) 
+  })
 
   try {
     // Sync each table
@@ -90,33 +122,52 @@ async function runSync(): Promise<Response> {
       results.push(await syncPhotos(notion, DB, R2_IMAGES, NOTION_DB_IDS.photos))
     }
 
-    // Log sync result
+    // Calculate totals
+    const duration = Date.now() - startTime
     const recordsSynced = results.reduce((sum, r) => sum + r.inserted + r.updated, 0)
+    const totalErrors = results.reduce((sum, r) => sum + r.errors.length, 0)
+
+    // Log sync result
     await DB.prepare(`
       INSERT INTO sync_log (sync_type, status, records_synced, error_message, completed_at)
-      VALUES ('notion_sync', 'success', ?, NULL, datetime('now'))
-    `).bind(recordsSynced).run()
+      VALUES ('notion_sync', ?, ?, ?, datetime('now'))
+    `).bind(
+      totalErrors > 0 ? 'partial' : 'success',
+      recordsSynced,
+      totalErrors > 0 ? `${totalErrors} record errors` : null
+    ).run()
+
+    logSync('info', 'Notion sync completed', { duration_ms: duration, recordsSynced, totalErrors })
 
     return new Response(JSON.stringify({
       success: true,
       duration_ms: duration,
+      records_synced: recordsSynced,
       results
     }), {
       headers: { 'Content-Type': 'application/json' }
     })
 
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    const duration = Date.now() - startTime
+    const errorMessage = formatError(error)
     
+    logSync('error', 'Notion sync failed', { duration_ms: duration, error: errorMessage })
+
     // Log failed sync
-    await DB.prepare(`
-      INSERT INTO sync_log (sync_type, status, records_synced, error_message, completed_at)
-      VALUES ('notion_sync', 'failed', 0, ?, datetime('now'))
-    `).bind(errorMessage).run()
+    try {
+      await DB.prepare(`
+        INSERT INTO sync_log (sync_type, status, records_synced, error_message, completed_at)
+        VALUES ('notion_sync', 'failed', 0, ?, datetime('now'))
+      `).bind(errorMessage).run()
+    } catch (dbError) {
+      logSync('error', 'Failed to log sync error to D1', { error: formatError(dbError) })
+    }
 
     return new Response(JSON.stringify({
       success: false,
       error: errorMessage,
+      duration_ms: duration,
       results
     }), {
       status: 500,
@@ -125,9 +176,26 @@ async function runSync(): Promise<Response> {
   }
 }
 
+/**
+ * Format an error into a string message.
+ * Handles Notion API errors, fetch timeout errors, and generic errors.
+ */
+function formatError(error: unknown): string {
+  if (isNotionClientError(error)) {
+    return `Notion API error: ${error.code} - ${error.message}`
+  }
+  if (error instanceof FetchTimeoutError) {
+    return error.message
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  return 'Unknown error'
+}
+
 // Helper to get all pages from a Notion database (handles pagination)
-async function getAllPages(notion: Client, databaseId: string) {
-  const pages: any[] = []
+async function getAllPages(notion: Client, databaseId: string): Promise<Array<Record<string, unknown>>> {
+  const pages: Array<Record<string, unknown>> = []
   let cursor: string | undefined
 
   do {
@@ -136,7 +204,7 @@ async function getAllPages(notion: Client, databaseId: string) {
       start_cursor: cursor,
       page_size: 100,
     })
-    pages.push(...response.results)
+    pages.push(...(response.results as Array<Record<string, unknown>>))
     cursor = response.has_more ? response.next_cursor ?? undefined : undefined
   } while (cursor)
 
@@ -144,29 +212,44 @@ async function getAllPages(notion: Client, databaseId: string) {
 }
 
 // Helper to extract property values from Notion
-function getNotionProp(page: any, name: string, type: string): any {
-  const prop = page.properties[name]
+function getNotionProp(page: Record<string, unknown>, name: string, type: string): unknown {
+  const properties = page.properties as Record<string, Record<string, unknown>> | undefined
+  if (!properties) return null
+  
+  const prop = properties[name]
   if (!prop) return null
 
   switch (type) {
-    case 'title':
-      return prop.title?.[0]?.plain_text || null
-    case 'rich_text':
-      return prop.rich_text?.[0]?.plain_text || null
+    case 'title': {
+      const titleArray = prop.title as Array<{ plain_text?: string }> | undefined
+      return titleArray?.[0]?.plain_text || null
+    }
+    case 'rich_text': {
+      const textArray = prop.rich_text as Array<{ plain_text?: string }> | undefined
+      return textArray?.[0]?.plain_text || null
+    }
     case 'number':
       return prop.number ?? null
-    case 'date':
-      return prop.date?.start || null
-    case 'select':
-      return prop.select?.name || null
-    case 'multi_select':
-      return prop.multi_select?.map((s: any) => s.name) || []
+    case 'date': {
+      const dateObj = prop.date as { start?: string } | null
+      return dateObj?.start || null
+    }
+    case 'select': {
+      const selectObj = prop.select as { name?: string } | null
+      return selectObj?.name || null
+    }
+    case 'multi_select': {
+      const multiSelect = prop.multi_select as Array<{ name?: string }> | undefined
+      return multiSelect?.map(s => s.name).filter(Boolean) || []
+    }
     case 'url':
       return prop.url || null
     case 'checkbox':
       return prop.checkbox ?? false
-    case 'files':
-      return prop.files?.[0]?.file?.url || prop.files?.[0]?.external?.url || null
+    case 'files': {
+      const files = prop.files as Array<{ file?: { url?: string }; external?: { url?: string } }> | undefined
+      return files?.[0]?.file?.url || files?.[0]?.external?.url || null
+    }
     default:
       return null
   }
@@ -174,26 +257,36 @@ function getNotionProp(page: any, name: string, type: string): any {
 
 async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise<SyncResult> {
   const result: SyncResult = { table: 'climbs', inserted: 0, updated: 0, errors: [] }
-  const pages = await getAllPages(notion, dbId)
+  
+  let pages: Array<Record<string, unknown>>
+  try {
+    pages = await getAllPages(notion, dbId)
+  } catch (error) {
+    result.errors.push(`Failed to fetch climbs: ${formatError(error)}`)
+    return result
+  }
+
+  logSync('info', 'Syncing climbs', { count: pages.length })
 
   for (const page of pages) {
     try {
-      const id = page.id.replace(/-/g, '')
+      const pageId = page.id as string
+      const id = pageId.replace(/-/g, '')
       const data = {
         id,
-        date: getNotionProp(page, 'Date', 'date'),
-        title: getNotionProp(page, 'Name', 'title'),
-        slug: getNotionProp(page, 'Slug', 'rich_text'),
-        preview_img_url: getNotionProp(page, 'Preview Image', 'files'),
-        distance: getNotionProp(page, 'Distance', 'number'),
-        gain: getNotionProp(page, 'Gain', 'number'),
-        max_elevation: getNotionProp(page, 'Max Elevation', 'number'),
-        moving_time: getNotionProp(page, 'Moving Time', 'number'),
-        area: getNotionProp(page, 'Area', 'select'),
-        state: getNotionProp(page, 'State', 'select'),
-        strava: getNotionProp(page, 'Strava', 'url'),
-        alltrails: getNotionProp(page, 'AllTrails', 'url'),
-        published: getNotionProp(page, 'Published', 'checkbox'),
+        date: getNotionProp(page, 'Date', 'date') as string | null,
+        title: getNotionProp(page, 'Name', 'title') as string | null,
+        slug: getNotionProp(page, 'Slug', 'rich_text') as string | null,
+        preview_img_url: getNotionProp(page, 'Preview Image', 'files') as string | null,
+        distance: getNotionProp(page, 'Distance', 'number') as number | null,
+        gain: getNotionProp(page, 'Gain', 'number') as number | null,
+        max_elevation: getNotionProp(page, 'Max Elevation', 'number') as number | null,
+        moving_time: getNotionProp(page, 'Moving Time', 'number') as number | null,
+        area: getNotionProp(page, 'Area', 'select') as string | null,
+        state: getNotionProp(page, 'State', 'select') as string | null,
+        strava: getNotionProp(page, 'Strava', 'url') as string | null,
+        alltrails: getNotionProp(page, 'AllTrails', 'url') as string | null,
+        published: getNotionProp(page, 'Published', 'checkbox') as boolean,
       }
 
       await db.prepare(`
@@ -222,7 +315,8 @@ async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise
 
       result.inserted++
     } catch (error) {
-      result.errors.push(`Climb ${page.id}: ${error}`)
+      const pageId = page.id as string
+      result.errors.push(`Climb ${pageId}: ${formatError(error)}`)
     }
   }
 
@@ -231,20 +325,30 @@ async function syncClimbs(notion: Client, db: D1Database, dbId: string): Promise
 
 async function syncPeaks(notion: Client, db: D1Database, dbId: string): Promise<SyncResult> {
   const result: SyncResult = { table: 'peaks', inserted: 0, updated: 0, errors: [] }
-  const pages = await getAllPages(notion, dbId)
+  
+  let pages: Array<Record<string, unknown>>
+  try {
+    pages = await getAllPages(notion, dbId)
+  } catch (error) {
+    result.errors.push(`Failed to fetch peaks: ${formatError(error)}`)
+    return result
+  }
+
+  logSync('info', 'Syncing peaks', { count: pages.length })
 
   for (const page of pages) {
     try {
-      const id = page.id.replace(/-/g, '')
+      const pageId = page.id as string
+      const id = pageId.replace(/-/g, '')
       const data = {
         id,
-        name: getNotionProp(page, 'Name', 'title'),
-        elevation: getNotionProp(page, 'Elevation', 'number'),
-        prominence: getNotionProp(page, 'Prominence', 'number'),
-        range: getNotionProp(page, 'Range', 'select'),
-        first_completed: getNotionProp(page, 'First Completed', 'date'),
-        attempts: getNotionProp(page, 'Attempts', 'number'),
-        list_class: getNotionProp(page, 'Class', 'select'),
+        name: getNotionProp(page, 'Name', 'title') as string | null,
+        elevation: getNotionProp(page, 'Elevation', 'number') as number | null,
+        prominence: getNotionProp(page, 'Prominence', 'number') as number | null,
+        range: getNotionProp(page, 'Range', 'select') as string | null,
+        first_completed: getNotionProp(page, 'First Completed', 'date') as string | null,
+        attempts: getNotionProp(page, 'Attempts', 'number') as number | null,
+        list_class: getNotionProp(page, 'Class', 'select') as string | null,
       }
 
       await db.prepare(`
@@ -266,7 +370,8 @@ async function syncPeaks(notion: Client, db: D1Database, dbId: string): Promise<
 
       result.inserted++
     } catch (error) {
-      result.errors.push(`Peak ${page.id}: ${error}`)
+      const pageId = page.id as string
+      result.errors.push(`Peak ${pageId}: ${formatError(error)}`)
     }
   }
 
@@ -275,23 +380,33 @@ async function syncPeaks(notion: Client, db: D1Database, dbId: string): Promise<
 
 async function syncGear(notion: Client, db: D1Database, dbId: string): Promise<SyncResult> {
   const result: SyncResult = { table: 'gear', inserted: 0, updated: 0, errors: [] }
-  const pages = await getAllPages(notion, dbId)
+  
+  let pages: Array<Record<string, unknown>>
+  try {
+    pages = await getAllPages(notion, dbId)
+  } catch (error) {
+    result.errors.push(`Failed to fetch gear: ${formatError(error)}`)
+    return result
+  }
+
+  logSync('info', 'Syncing gear', { count: pages.length })
 
   for (const page of pages) {
     try {
-      const id = page.id.replace(/-/g, '')
+      const pageId = page.id as string
+      const id = pageId.replace(/-/g, '')
       const data = {
         id,
-        name: getNotionProp(page, 'Name', 'title'),
-        brand: getNotionProp(page, 'Brand', 'select'),
-        category: getNotionProp(page, 'Category', 'select'),
-        weight_oz: getNotionProp(page, 'Weight (oz)', 'number'),
-        price: getNotionProp(page, 'Price', 'number'),
-        rating: getNotionProp(page, 'Rating', 'number'),
-        status: getNotionProp(page, 'Status', 'select'),
-        notes: getNotionProp(page, 'Notes', 'rich_text'),
-        url: getNotionProp(page, 'URL', 'url'),
-        image_url: getNotionProp(page, 'Image', 'files'),
+        name: getNotionProp(page, 'Name', 'title') as string | null,
+        brand: getNotionProp(page, 'Brand', 'select') as string | null,
+        category: getNotionProp(page, 'Category', 'select') as string | null,
+        weight_oz: getNotionProp(page, 'Weight (oz)', 'number') as number | null,
+        price: getNotionProp(page, 'Price', 'number') as number | null,
+        rating: getNotionProp(page, 'Rating', 'number') as number | null,
+        status: getNotionProp(page, 'Status', 'select') as string | null,
+        notes: getNotionProp(page, 'Notes', 'rich_text') as string | null,
+        url: getNotionProp(page, 'URL', 'url') as string | null,
+        image_url: getNotionProp(page, 'Image', 'files') as string | null,
       }
 
       await db.prepare(`
@@ -317,7 +432,8 @@ async function syncGear(notion: Client, db: D1Database, dbId: string): Promise<S
 
       result.inserted++
     } catch (error) {
-      result.errors.push(`Gear ${page.id}: ${error}`)
+      const pageId = page.id as string
+      result.errors.push(`Gear ${pageId}: ${formatError(error)}`)
     }
   }
 
@@ -326,21 +442,31 @@ async function syncGear(notion: Client, db: D1Database, dbId: string): Promise<S
 
 async function syncPhotos(notion: Client, db: D1Database, r2: R2Bucket | undefined, dbId: string): Promise<SyncResult> {
   const result: SyncResult = { table: 'photos', inserted: 0, updated: 0, errors: [] }
-  const pages = await getAllPages(notion, dbId)
+  
+  let pages: Array<Record<string, unknown>>
+  try {
+    pages = await getAllPages(notion, dbId)
+  } catch (error) {
+    result.errors.push(`Failed to fetch photos: ${formatError(error)}`)
+    return result
+  }
+
+  logSync('info', 'Syncing photos', { count: pages.length })
 
   for (const page of pages) {
     try {
-      const id = page.id.replace(/-/g, '')
+      const pageId = page.id as string
+      const id = pageId.replace(/-/g, '')
       
       // Get raw Notion properties
-      const url = getNotionProp(page, 'href', 'url') || getNotionProp(page, 'Image', 'files')
-      const caption = getNotionProp(page, 'Caption', 'title') || getNotionProp(page, 'Name', 'title')
-      const dateRaw = getNotionProp(page, 'Date', 'date')
-      const areaFallback = getNotionProp(page, 'area_fallback', 'rich_text')
-      const tagsRaw = getNotionProp(page, 'tags', 'rich_text')
-      const width = getNotionProp(page, 'width', 'number')
-      const height = getNotionProp(page, 'height', 'number')
-      const exclude = getNotionProp(page, 'exclude', 'checkbox')
+      const url = (getNotionProp(page, 'href', 'url') || getNotionProp(page, 'Image', 'files')) as string | null
+      const caption = (getNotionProp(page, 'Caption', 'title') || getNotionProp(page, 'Name', 'title')) as string | null
+      const dateRaw = getNotionProp(page, 'Date', 'date') as string | null
+      const areaFallback = getNotionProp(page, 'area_fallback', 'rich_text') as string | null
+      const tagsRaw = getNotionProp(page, 'tags', 'rich_text') as string | null
+      const width = getNotionProp(page, 'width', 'number') as number | null
+      const height = getNotionProp(page, 'height', 'number') as number | null
+      const exclude = getNotionProp(page, 'exclude', 'checkbox') as boolean
 
       if (!url) continue // Skip photos without images
 
@@ -348,44 +474,10 @@ async function syncPhotos(notion: Client, db: D1Database, r2: R2Bucket | undefin
       const date = dateRaw ? dateRaw.split('T')[0] : null
 
       // Parse area_fallback into area and state
-      // Formats: "Area Name, State" or "Area Name- State" or "Area Name - State"
-      let area: string | null = null
-      let state: string | null = null
-      
-      if (areaFallback) {
-        // Try comma separator first
-        if (areaFallback.includes(',')) {
-          const parts = areaFallback.split(',').map((s: string) => s.trim())
-          area = parts[0] || null
-          state = normalizeStateName(parts[1]) || null
-        }
-        // Try dash separator
-        else if (areaFallback.includes('-')) {
-          const parts = areaFallback.split('-').map((s: string) => s.trim())
-          area = parts[0] || null
-          state = normalizeStateName(parts[1]) || null
-        }
-        // No separator - just area
-        else {
-          area = areaFallback
-        }
-        
-        // Clean up area spacing (e.g., "Bridger- Teton" → "Bridger-Teton")
-        if (area) {
-          area = area.replace(/\s*-\s*/g, '-').trim()
-        }
-      }
+      const { area, state } = parseAreaFallback(areaFallback)
 
       // Parse tags: lowercase, trim, dedupe, sort alphabetically
-      let searchTags: string | null = null
-      if (tagsRaw) {
-        const tags = tagsRaw
-          .split(',')
-          .map((t: string) => t.trim().toLowerCase())
-          .filter((t: string) => t.length > 0)
-        const uniqueTags = Array.from(new Set(tags)).sort()
-        searchTags = uniqueTags.join(', ')
-      }
+      const searchTags = parseTags(tagsRaw)
 
       // Derive format from URL extension
       const ext = url.split('.').pop()?.toLowerCase() || 'jpg'
@@ -393,8 +485,7 @@ async function syncPhotos(notion: Client, db: D1Database, r2: R2Bucket | undefin
       const r2Key = `photos/${id}`
 
       // Generate deterministic short_id from Notion page ID for clean URLs
-      // This ensures the same photo always gets the same short_id, preventing URL breakage
-      const shortId = await generateShortId(page.id)
+      const shortId = await generateShortId(pageId)
 
       await db.prepare(`
         INSERT INTO photos (
@@ -428,36 +519,114 @@ async function syncPhotos(notion: Client, db: D1Database, r2: R2Bucket | undefin
 
       // Sync image to R2 so we can serve from our own storage
       if (r2) {
-        try {
-          const r2ObjectKey = `${r2Key}/original.${format}`
-          const existing = await r2.head(r2ObjectKey)
-
-          if (!existing) {
-            const imgRes = await fetch(url)
-            if (imgRes.ok) {
-              const buffer = await imgRes.arrayBuffer()
-              const contentType = imgRes.headers.get('content-type') || `image/${format}`
-              await r2.put(r2ObjectKey, buffer, {
-                httpMetadata: { contentType },
-              })
-            }
-          }
-        } catch (r2Error) {
-          // Don't fail the whole sync if one image upload fails
-          console.error(`Failed to sync image ${id} to R2:`, r2Error)
-        }
+        await syncImageToR2(r2, r2Key, format, url, id)
       }
 
       result.inserted++
     } catch (error) {
-      result.errors.push(`Photo ${page.id}: ${error}`)
+      const pageId = page.id as string
+      result.errors.push(`Photo ${pageId}: ${formatError(error)}`)
     }
   }
 
   return result
 }
 
-// Helper to normalize state names to full names
+/**
+ * Sync an image from a URL to R2 storage.
+ * Uses fetch with timeout to prevent hanging on slow/unresponsive servers.
+ */
+async function syncImageToR2(
+  r2: R2Bucket,
+  r2Key: string,
+  format: string,
+  url: string,
+  photoId: string
+): Promise<void> {
+  try {
+    const r2ObjectKey = `${r2Key}/original.${format}`
+    const existing = await r2.head(r2ObjectKey)
+
+    if (!existing) {
+      const imgRes = await fetchImage(url, IMAGE_TIMEOUT_MS)
+      if (imgRes.ok) {
+        const buffer = await imgRes.arrayBuffer()
+        const contentType = imgRes.headers.get('content-type') || `image/${format}`
+        await r2.put(r2ObjectKey, buffer, {
+          httpMetadata: { contentType },
+        })
+      } else {
+        logSync('warn', 'Failed to fetch image', { 
+          photoId, 
+          url, 
+          status: imgRes.status 
+        })
+      }
+    }
+  } catch (error) {
+    // Don't fail the whole sync if one image upload fails
+    logSync('warn', 'Failed to sync image to R2', { 
+      photoId, 
+      url, 
+      error: formatError(error) 
+    })
+  }
+}
+
+/**
+ * Parse area_fallback into area and state.
+ * Formats: "Area Name, State" or "Area Name- State" or "Area Name - State"
+ */
+function parseAreaFallback(areaFallback: string | null): { area: string | null; state: string | null } {
+  if (!areaFallback) {
+    return { area: null, state: null }
+  }
+
+  let area: string | null = null
+  let state: string | null = null
+
+  // Try comma separator first
+  if (areaFallback.includes(',')) {
+    const parts = areaFallback.split(',').map(s => s.trim())
+    area = parts[0] || null
+    state = normalizeStateName(parts[1]) || null
+  }
+  // Try dash separator
+  else if (areaFallback.includes('-')) {
+    const parts = areaFallback.split('-').map(s => s.trim())
+    area = parts[0] || null
+    state = normalizeStateName(parts[1]) || null
+  }
+  // No separator - just area
+  else {
+    area = areaFallback
+  }
+
+  // Clean up area spacing (e.g., "Bridger- Teton" → "Bridger-Teton")
+  if (area) {
+    area = area.replace(/\s*-\s*/g, '-').trim()
+  }
+
+  return { area, state }
+}
+
+/**
+ * Parse tags string into normalized, deduplicated, sorted format.
+ */
+function parseTags(tagsRaw: string | null): string | null {
+  if (!tagsRaw) return null
+  
+  const tags = tagsRaw
+    .split(',')
+    .map(t => t.trim().toLowerCase())
+    .filter(t => t.length > 0)
+  const uniqueTags = Array.from(new Set(tags)).sort()
+  return uniqueTags.length > 0 ? uniqueTags.join(', ') : null
+}
+
+/**
+ * Normalize state names to full names.
+ */
 function normalizeStateName(state: string | null | undefined): string | null {
   if (!state) return null
   

--- a/src/pages/api/photos/[...path].ts
+++ b/src/pages/api/photos/[...path].ts
@@ -5,15 +5,19 @@ import { createPhotosApp } from '../../../../utils/photos-api'
 export const prerender = false
 
 /**
- * Create the photos Hono app with bindings from the Cloudflare environment.
- * Factored out to avoid duplication across HTTP methods.
+ * Build the photos Hono app once per isolate and reuse it across requests.
+ * Lazily initialized so the Cloudflare `env` binding is available on first use.
  */
+let photosApp: ReturnType<typeof createPhotosApp> | undefined
 function getPhotosApp() {
-  return createPhotosApp({
-    DB: env.DB,
-    R2_IMAGES: env.R2_IMAGES,
-    IMAGES: env.IMAGES,
-  })
+  if (!photosApp) {
+    photosApp = createPhotosApp({
+      DB: env.DB,
+      R2_IMAGES: env.R2_IMAGES,
+      IMAGES: env.IMAGES,
+    })
+  }
+  return photosApp
 }
 
 // Handles all /api/photos/* routes

--- a/src/pages/api/photos/[...path].ts
+++ b/src/pages/api/photos/[...path].ts
@@ -4,39 +4,31 @@ import { createPhotosApp } from '../../../../utils/photos-api'
 
 export const prerender = false
 
+/**
+ * Create the photos Hono app with bindings from the Cloudflare environment.
+ * Factored out to avoid duplication across HTTP methods.
+ */
+function getPhotosApp() {
+  return createPhotosApp({
+    DB: env.DB,
+    R2_IMAGES: env.R2_IMAGES,
+    IMAGES: env.IMAGES,
+  })
+}
+
 // Handles all /api/photos/* routes
 export const GET: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }
 
 export const POST: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }
 
 export const PATCH: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }
 
 export const DELETE: APIRoute = async ({ request }) => {
-  const app = createPhotosApp({
-    DB: env.DB as D1Database,
-    R2_IMAGES: env.R2_IMAGES as R2Bucket,
-    IMAGES: (env as any).IMAGES as ImagesBinding,
-  })
-  return app.fetch(request)
+  return getPhotosApp().fetch(request)
 }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -471,7 +471,7 @@ const slug = post.id.replace(/\.md$/, '')
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
               const id = entry.target.id
-              document.querySelectorAll('.toc-link').forEach((link) => {
+              document.querySelectorAll<HTMLElement>('.toc-link').forEach((link) => {
                 link.classList.remove('active')
                 if (link.dataset.target === id) {
                   link.classList.add('active')
@@ -489,10 +489,10 @@ const slug = post.id.replace(/\.md$/, '')
       headings.forEach((heading) => observer.observe(heading))
 
       // Smooth scroll on TOC link click
-      document.querySelectorAll('.toc-link').forEach((link) => {
+      document.querySelectorAll<HTMLElement>('.toc-link').forEach((link) => {
         link.addEventListener('click', (e) => {
           e.preventDefault()
-          const target = document.getElementById(link.dataset.target)
+          const target = document.getElementById(link.dataset.target ?? '')
           if (target) {
             target.scrollIntoView({ behavior: 'smooth', block: 'start' })
             history.pushState(null, '', '#' + link.dataset.target)

--- a/src/pages/climbs.astro
+++ b/src/pages/climbs.astro
@@ -3,19 +3,20 @@ import Layout from '../layouts/Layout.astro'
 import ClimbTable from '../components/ClimbTable'
 import { fillMissingPreviewImages } from '../lib/photo-fallbacks'
 import { env } from 'cloudflare:workers'
+import type { ClimbListItem } from '../lib/types'
 
 export const prerender = false
 
-const DB = env.DB as D1Database | undefined
+const DB = env.DB
 
-let climbs: any[] = []
+let climbs: ClimbListItem[] = []
 
 if (DB) {
   try {
-    // Fetch climbs
+    // Fetch climbs with only the fields needed for the list view
     const result = await DB.prepare(
       'SELECT id, date, title, slug, preview_img_url, distance, gain, area, state, strava FROM climbs ORDER BY date DESC'
-    ).all()
+    ).all<ClimbListItem>()
     climbs = result.results || []
 
     // Fill missing preview images from photos table (200px thumbnails for table)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,6 @@ const DB = env.DB as D1Database | undefined
 
 let recentClimbs: any[] = []
 let heroPhotos: { short_id: string; accent_color: string | null }[] = []
-let heroAccentColor: string | null = null
 let stats = { totalClimbs: 0, totalPeaks: 0, totalMiles: 0, totalGain: 0 }
 
 if (DB) {
@@ -38,7 +37,7 @@ if (DB) {
         (SELECT COUNT(*) FROM peaks WHERE first_completed IS NOT NULL) as totalPeaks,
         (SELECT COALESCE(SUM(distance), 0) FROM climbs) as totalMiles,
         (SELECT COALESCE(SUM(gain), 0) FROM climbs) as totalGain
-    `).first()
+    `).first<{ totalClimbs: number; totalPeaks: number; totalMiles: number; totalGain: number }>()
     
     if (statsResult) {
       stats = {
@@ -136,7 +135,7 @@ function formatNumber(n: number): string {
 
   <script>
     // Cycle hero image through last 5 photos
-    const heroSection = document.querySelector('.hero');
+    const heroSection = document.querySelector<HTMLElement>('.hero');
     const heroImage = document.getElementById('hero-image');
     if (heroSection && heroImage) {
       const photos = JSON.parse(heroSection.dataset.photos || '[]');

--- a/src/pages/peaks.astro
+++ b/src/pages/peaks.astro
@@ -282,14 +282,13 @@ function formatElevation(feet: number) {
   </style>
 
   <script>
-    const buttons = document.querySelectorAll('.filter-btn')
-    const cards = document.querySelectorAll('.peak-card')
+    const buttons = document.querySelectorAll<HTMLElement>('.filter-btn')
+    const cards = document.querySelectorAll<HTMLElement>('.peak-card')
     const countEl = document.getElementById('visible-count')
-    const totalCards = cards.length
 
     function updateCount() {
       const visible = Array.from(cards).filter(c => c.style.display !== 'none').length
-      if (countEl) countEl.textContent = visible
+      if (countEl) countEl.textContent = String(visible)
     }
 
     buttons.forEach(btn => {

--- a/tests/fixtures/notion-mocks.ts
+++ b/tests/fixtures/notion-mocks.ts
@@ -67,7 +67,7 @@ export const mockPhotoPage = {
 export function createMockNotion(pages: any[] = []) {
   return {
     databases: {
-      query: async ({ database_id, start_cursor, page_size }: any) => ({
+      query: async () => ({
         results: pages,
         has_more: false,
         next_cursor: null,
@@ -75,7 +75,7 @@ export function createMockNotion(pages: any[] = []) {
     },
     blocks: {
       children: {
-        list: async ({ block_id }: any) => ({
+        list: async () => ({
           results: [
             {
               type: 'paragraph',

--- a/tests/fixtures/notion-mocks.ts
+++ b/tests/fixtures/notion-mocks.ts
@@ -1,0 +1,93 @@
+/**
+ * Mock Notion API responses for testing
+ */
+
+export const mockClimbPage = {
+  id: '18e01b50-4364-8024-85d8-e12aba9ac803',
+  properties: {
+    Name: { title: [{ plain_text: 'Green Mountain' }] },
+    Date: { date: { start: '2024-06-15' } },
+    Slug: { rich_text: [{ plain_text: 'green-mountain-june-2024' }] },
+    'Preview Image': { files: [{ file: { url: 'https://example.com/img.jpg' } }] },
+    Distance: { number: 8.5 },
+    Gain: { number: 2800 },
+    'Max Elevation': { number: 14264 },
+    'Moving Time': { number: 240 },
+    Area: { select: { name: 'Front Range' } },
+    State: { select: { name: 'Colorado' } },
+    Strava: { url: 'https://strava.com/activities/123' },
+    AllTrails: { url: null },
+    Published: { checkbox: true },
+  },
+}
+
+export const mockPeakPage = {
+  id: '28e01b50-4364-8024-85d8-e12aba9ac804',
+  properties: {
+    Name: { title: [{ plain_text: 'Longs Peak' }] },
+    Elevation: { number: 14255 },
+    Prominence: { number: 2920 },
+    Range: { select: { name: 'Front Range' } },
+    'First Completed': { date: { start: '2023-08-10' } },
+    Attempts: { number: 2 },
+    Class: { select: { name: '3' } },
+  },
+}
+
+export const mockGearPage = {
+  id: '38e01b50-4364-8024-85d8-e12aba9ac805',
+  properties: {
+    Name: { title: [{ plain_text: 'Garmin InReach Mini' }] },
+    Brand: { select: { name: 'Garmin' } },
+    Category: { select: { name: 'Electronics' } },
+    'Weight (oz)': { number: 3.5 },
+    Price: { number: 350 },
+    Rating: { number: 5 },
+    Status: { select: { name: 'Own' } },
+    Notes: { rich_text: [{ plain_text: 'Essential for solo hikes' }] },
+    URL: { url: 'https://rei.com/product/123' },
+    Image: { files: [{ external: { url: 'https://example.com/garmin.jpg' } }] },
+  },
+}
+
+export const mockPhotoPage = {
+  id: '48e01b50-4364-8024-85d8-e12aba9ac806',
+  properties: {
+    href: { url: 'https://example.com/photo.jpg' },
+    Caption: { title: [{ plain_text: 'Summit view at sunrise' }] },
+    Date: { date: { start: '2024-06-15T06:30:00' } },
+    area_fallback: { rich_text: [{ plain_text: 'Front Range, Colorado' }] },
+    tags: { rich_text: [{ plain_text: 'sunrise, summit, 14er' }] },
+    width: { number: 4000 },
+    height: { number: 3000 },
+    exclude: { checkbox: false },
+  },
+}
+
+export function createMockNotion(pages: any[] = []) {
+  return {
+    databases: {
+      query: async ({ database_id, start_cursor, page_size }: any) => ({
+        results: pages,
+        has_more: false,
+        next_cursor: null,
+      }),
+    },
+    blocks: {
+      children: {
+        list: async ({ block_id }: any) => ({
+          results: [
+            {
+              type: 'paragraph',
+              paragraph: {
+                rich_text: [{ plain_text: 'Test content from Notion' }],
+              },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        }),
+      },
+    },
+  }
+}

--- a/tests/unit/cron-sync.test.ts
+++ b/tests/unit/cron-sync.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for the pure helpers used by the Notion -> D1 cron sync.
+ *
+ * These import the real implementations from `src/lib/notion-helpers.ts`
+ * (rather than copies) so the tests fail if production behavior drifts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getNotionProp,
+  normalizeStateName,
+  parseAreaFallback,
+  parseTags,
+} from '../../src/lib/notion-helpers'
+import {
+  mockClimbPage,
+  mockPeakPage,
+  mockGearPage,
+  mockPhotoPage,
+} from '../fixtures/notion-mocks'
+
+describe('getNotionProp', () => {
+  describe('Climb properties', () => {
+    it('extracts title from Name property', () => {
+      expect(getNotionProp(mockClimbPage, 'Name', 'title')).toBe('Green Mountain')
+    })
+
+    it('extracts date from Date property', () => {
+      expect(getNotionProp(mockClimbPage, 'Date', 'date')).toBe('2024-06-15')
+    })
+
+    it('extracts slug from rich_text', () => {
+      expect(getNotionProp(mockClimbPage, 'Slug', 'rich_text')).toBe('green-mountain-june-2024')
+    })
+
+    it('extracts numeric values', () => {
+      expect(getNotionProp(mockClimbPage, 'Distance', 'number')).toBe(8.5)
+      expect(getNotionProp(mockClimbPage, 'Gain', 'number')).toBe(2800)
+      expect(getNotionProp(mockClimbPage, 'Max Elevation', 'number')).toBe(14264)
+    })
+
+    it('extracts select values', () => {
+      expect(getNotionProp(mockClimbPage, 'Area', 'select')).toBe('Front Range')
+      expect(getNotionProp(mockClimbPage, 'State', 'select')).toBe('Colorado')
+    })
+
+    it('extracts checkbox values', () => {
+      expect(getNotionProp(mockClimbPage, 'Published', 'checkbox')).toBe(true)
+    })
+
+    it('extracts file URLs', () => {
+      expect(getNotionProp(mockClimbPage, 'Preview Image', 'files')).toBe('https://example.com/img.jpg')
+    })
+
+    it('returns null for missing properties', () => {
+      expect(getNotionProp(mockClimbPage, 'NonExistent', 'title')).toBeNull()
+    })
+
+    it('returns null for null URLs', () => {
+      expect(getNotionProp(mockClimbPage, 'AllTrails', 'url')).toBeNull()
+    })
+
+    it('returns null when the page has no properties', () => {
+      expect(getNotionProp({ id: 'x' }, 'Name', 'title')).toBeNull()
+    })
+  })
+
+  describe('Peak properties', () => {
+    it('extracts peak name', () => {
+      expect(getNotionProp(mockPeakPage, 'Name', 'title')).toBe('Longs Peak')
+    })
+
+    it('extracts elevation and prominence', () => {
+      expect(getNotionProp(mockPeakPage, 'Elevation', 'number')).toBe(14255)
+      expect(getNotionProp(mockPeakPage, 'Prominence', 'number')).toBe(2920)
+    })
+
+    it('extracts class as select', () => {
+      expect(getNotionProp(mockPeakPage, 'Class', 'select')).toBe('3')
+    })
+  })
+
+  describe('Gear properties', () => {
+    it('extracts gear name and brand', () => {
+      expect(getNotionProp(mockGearPage, 'Name', 'title')).toBe('Garmin InReach Mini')
+      expect(getNotionProp(mockGearPage, 'Brand', 'select')).toBe('Garmin')
+    })
+
+    it('extracts external file URL', () => {
+      expect(getNotionProp(mockGearPage, 'Image', 'files')).toBe('https://example.com/garmin.jpg')
+    })
+
+    it('extracts notes as rich_text', () => {
+      expect(getNotionProp(mockGearPage, 'Notes', 'rich_text')).toBe('Essential for solo hikes')
+    })
+  })
+
+  describe('Photo properties', () => {
+    it('extracts photo URL from href', () => {
+      expect(getNotionProp(mockPhotoPage, 'href', 'url')).toBe('https://example.com/photo.jpg')
+    })
+
+    it('extracts caption from title', () => {
+      expect(getNotionProp(mockPhotoPage, 'Caption', 'title')).toBe('Summit view at sunrise')
+    })
+
+    it('extracts dimensions', () => {
+      expect(getNotionProp(mockPhotoPage, 'width', 'number')).toBe(4000)
+      expect(getNotionProp(mockPhotoPage, 'height', 'number')).toBe(3000)
+    })
+  })
+})
+
+describe('normalizeStateName', () => {
+  it('normalizes state abbreviations', () => {
+    expect(normalizeStateName('CO')).toBe('Colorado')
+    expect(normalizeStateName('WY')).toBe('Wyoming')
+    expect(normalizeStateName('UT')).toBe('Utah')
+  })
+
+  it('handles full state names', () => {
+    expect(normalizeStateName('Alaska')).toBe('Alaska')
+    expect(normalizeStateName('Washington State')).toBe('Washington')
+  })
+
+  it('passes through unknown values', () => {
+    expect(normalizeStateName('Unknown State')).toBe('Unknown State')
+  })
+
+  it('handles null and undefined', () => {
+    expect(normalizeStateName(null)).toBeNull()
+    expect(normalizeStateName(undefined)).toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    expect(normalizeStateName('  CO  ')).toBe('Colorado')
+  })
+})
+
+describe('parseAreaFallback', () => {
+  it('parses comma-separated format and normalizes state', () => {
+    const result = parseAreaFallback('Front Range, Colorado')
+    expect(result.area).toBe('Front Range')
+    expect(result.state).toBe('Colorado')
+  })
+
+  it('treats a whitespace-adjacent dash as the area/state separator', () => {
+    const result = parseAreaFallback('Bridger-Teton - Wyoming')
+    expect(result.area).toBe('Bridger-Teton')
+    expect(result.state).toBe('Wyoming')
+  })
+
+  it('handles a dash with a trailing space only', () => {
+    const result = parseAreaFallback('Front Range- CO')
+    expect(result.area).toBe('Front Range')
+    expect(result.state).toBe('Colorado')
+  })
+
+  it('preserves internal hyphens when there is no state', () => {
+    const result = parseAreaFallback('Bridger-Teton')
+    expect(result.area).toBe('Bridger-Teton')
+    expect(result.state).toBeNull()
+  })
+
+  it('handles area-only input', () => {
+    const result = parseAreaFallback('Front Range')
+    expect(result.area).toBe('Front Range')
+    expect(result.state).toBeNull()
+  })
+
+  it('handles null input', () => {
+    const result = parseAreaFallback(null)
+    expect(result.area).toBeNull()
+    expect(result.state).toBeNull()
+  })
+
+  it('cleans up spacing around dashes in area names (comma format)', () => {
+    const result = parseAreaFallback('Bridger - Teton, WY')
+    expect(result.area).toBe('Bridger-Teton')
+    expect(result.state).toBe('Wyoming')
+  })
+})
+
+describe('parseTags', () => {
+  it('lowercases, trims, dedupes, and sorts tags', () => {
+    expect(parseTags('sunrise, summit, 14er')).toBe('14er, summit, sunrise')
+  })
+
+  it('deduplicates case-insensitively', () => {
+    expect(parseTags('B, a, b, A')).toBe('a, b')
+  })
+
+  it('returns null for null input', () => {
+    expect(parseTags(null)).toBeNull()
+  })
+
+  it('returns null for whitespace/empty input', () => {
+    expect(parseTags('   ')).toBeNull()
+    expect(parseTags(', ,')).toBeNull()
+  })
+})
+
+describe('Notion ID storage convention', () => {
+  it('stores the original page ID with dashes and a stripped id', () => {
+    const pageId = '18e01b50-4364-8024-85d8-e12aba9ac803'
+    expect(pageId).toBe('18e01b50-4364-8024-85d8-e12aba9ac803')
+    expect(pageId.replace(/-/g, '')).toBe('18e01b504364802485d8e12aba9ac803')
+  })
+})

--- a/utils/photos-api.ts
+++ b/utils/photos-api.ts
@@ -32,7 +32,6 @@ async function generateShortId(input: string): Promise<string> {
 
 // Supported widths for public image transforms
 const ALLOWED_WIDTHS = new Set([200, 400, 800, 1600]);
-const MAX_CUSTOM_WIDTH = 2048;
 
 // In-flight transform tracking to prevent duplicate work
 const inFlightTransforms = new Map<string, Promise<any>>();

--- a/utils/photos-api.ts
+++ b/utils/photos-api.ts
@@ -10,6 +10,23 @@
  */
 
 import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import {
+  updatePhotoSchema,
+  resizePhotoSchema,
+  extractColorsSchema,
+} from "../src/lib/schemas";
+
+/**
+ * Format Zod validation errors into a user-friendly message.
+ * Inline to avoid Zod v4 type compatibility issues with exported function.
+ */
+function formatValidationError(error: { issues: { path: PropertyKey[]; message: string }[] }): string {
+  return error.issues.map(issue => {
+    const path = issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : ''
+    return `${path}${issue.message}`
+  }).join('; ')
+}
 
 // Generate a short URL-safe ID from any string (used for cleaner /img/{id} URLs)
 // Must match the Python: hashlib.sha256(input.encode()).hexdigest()[:8]
@@ -617,50 +634,83 @@ export function createPhotosApp(env: PhotosApiEnv) {
   // ============ ADMIN API ROUTES ============
 
   // PATCH /api/admin/photos/{id} - Edit metadata
-  app.patch("/api/admin/photos/:id", async (c) => {
-    const id = c.req.param("id");
-    const body = await c.req.json().catch(() => ({}));
+  app.patch(
+    "/api/admin/photos/:id",
+    zValidator("json", updatePhotoSchema, (result, c) => {
+      if (!result.success) {
+        return c.json({ error: formatValidationError(result.error) }, 400);
+      }
+    }),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = c.req.valid("json");
 
-    // Resolve short_id to full id
-    let photoId = id;
-    const shortLookup = await env.DB.prepare("SELECT id FROM photos WHERE short_id = ?")
-      .bind(id)
-      .first<{ id: string }>();
-    if (shortLookup) photoId = shortLookup.id;
+      // Resolve short_id to full id
+      let photoId = id;
+      const shortLookup = await env.DB.prepare("SELECT id FROM photos WHERE short_id = ?")
+        .bind(id)
+        .first<{ id: string }>();
+      if (shortLookup) photoId = shortLookup.id;
 
-    const allowedFields = ["title", "location", "date", "tags", "site", "exclude", "caption"];
-    const updateFields: string[] = [];
-    const updateValues: (string | number | null)[] = [];
+      // Check photo exists
+      const existingPhoto = await env.DB.prepare("SELECT id FROM photos WHERE id = ?")
+        .bind(photoId)
+        .first<{ id: string }>();
+      if (!existingPhoto) {
+        return c.json({ error: "Photo not found" }, 404);
+      }
 
-    for (const field of allowedFields) {
-      if (field in body) {
-        const value = body[field];
-        updateFields.push(field);
-        if (field === "exclude") {
-          updateValues.push(value ? 1 : 0);
-        } else {
-          updateValues.push(value === null ? null : String(value));
-        }
+      const updateFields: string[] = [];
+      const updateValues: (string | number | null)[] = [];
+
+      // Type-safe field extraction from validated body
+      if (body.title !== undefined) {
+        updateFields.push("title");
+        updateValues.push(body.title);
+      }
+      if (body.location !== undefined) {
+        updateFields.push("location");
+        updateValues.push(body.location);
+      }
+      if (body.date !== undefined) {
+        updateFields.push("date");
+        updateValues.push(body.date);
+      }
+      if (body.tags !== undefined) {
+        updateFields.push("tags");
+        updateValues.push(body.tags);
+      }
+      if (body.site !== undefined) {
+        updateFields.push("site");
+        updateValues.push(body.site);
+      }
+      if (body.exclude !== undefined) {
+        updateFields.push("exclude");
+        updateValues.push(body.exclude ? 1 : 0);
+      }
+      if (body.caption !== undefined) {
+        updateFields.push("caption");
+        updateValues.push(body.caption);
+      }
+
+      if (updateFields.length === 0) {
+        return c.json({ error: "No valid fields to update" }, 400);
+      }
+
+      const setClause = updateFields.map(f => `${f} = ?`).join(", ") + ", updated_at = datetime('now')";
+      updateValues.push(photoId); // for WHERE clause
+
+      try {
+        await env.DB.prepare(`UPDATE photos SET ${setClause} WHERE id = ?`).bind(...updateValues).run();
+        const photo = await env.DB.prepare("SELECT * FROM photos WHERE id = ?")
+          .bind(photoId)
+          .first<Photo>();
+        return c.json(photo);
+      } catch (error) {
+        return c.json({ error: "Update failed" }, 500);
       }
     }
-
-    if (updateFields.length === 0) {
-      return c.json({ error: "No valid fields to update" }, 400);
-    }
-
-    const setClause = updateFields.map(f => `${f} = ?`).join(", ") + ", updated_at = datetime('now')";
-    updateValues.push(photoId); // for WHERE clause
-
-    try {
-      await env.DB.prepare(`UPDATE photos SET ${setClause} WHERE id = ?`).bind(...updateValues).run();
-      const photo = await env.DB.prepare("SELECT * FROM photos WHERE id = ?")
-        .bind(photoId)
-        .first<Photo>();
-      return c.json(photo);
-    } catch (error) {
-      return c.json({ error: "Update failed" }, 500);
-    }
-  });
+  );
 
   // DELETE /api/admin/photos/{id} - Delete photo
   app.delete("/api/admin/photos/:id", async (c) => {
@@ -697,68 +747,71 @@ export function createPhotosApp(env: PhotosApiEnv) {
   });
 
   // POST /api/admin/resize - Custom resize
-  app.post("/api/admin/photos/resize", async (c) => {
-    const body = await c.req.json().catch(() => ({}));
-    const { photoId, width } = body;
+  app.post(
+    "/api/admin/photos/resize",
+    zValidator("json", resizePhotoSchema, (result, c) => {
+      if (!result.success) {
+        return c.json({ error: formatValidationError(result.error) }, 400);
+      }
+    }),
+    async (c) => {
+      const { photoId, width } = c.req.valid("json");
 
-    if (!photoId || !width) {
-      return c.json({ error: "photoId and width required" }, 400);
-    }
-
-    const w = parseInt(width, 10);
-    if (Number.isNaN(w) || w < 1 || w > MAX_CUSTOM_WIDTH) {
-      return c.json({ error: `width must be between 1 and ${MAX_CUSTOM_WIDTH}` }, 400);
-    }
-
-    let photo = await env.DB.prepare("SELECT * FROM photos WHERE id = ?")
-      .bind(photoId)
-      .first<Photo>();
-
-    if (!photo) {
-      photo = await env.DB.prepare("SELECT * FROM photos WHERE short_id = ?")
+      let photo = await env.DB.prepare("SELECT * FROM photos WHERE id = ?")
         .bind(photoId)
         .first<Photo>();
+
+      if (!photo) {
+        photo = await env.DB.prepare("SELECT * FROM photos WHERE short_id = ?")
+          .bind(photoId)
+          .first<Photo>();
+      }
+
+      if (!photo) return c.json({ error: "Photo not found" }, 404);
+
+      const r2Key = `${photo.r2_key}/w${width}.webp`;
+
+      const existing = await env.R2_IMAGES.get(r2Key);
+      if (existing) {
+        const origin = new URL(c.req.url).origin;
+        return c.json({ url: `${origin}/img/${photoId}?w=${width}`, cached: true, width });
+      }
+
+      const originalKey = `${photo.r2_key}/original.${photo.format}`;
+      const original = await env.R2_IMAGES.get(originalKey);
+      if (!original) return c.json({ error: "Original not found" }, 404);
+
+      try {
+        const transformed = await env.IMAGES.input(original.body)
+          .transform({ width, fit: "scale-down" })
+          .output({ format: "image/webp", quality: 85 });
+
+        const buffer = await transformed.response().arrayBuffer();
+        await env.R2_IMAGES.put(r2Key, buffer, {
+          httpMetadata: { contentType: "image/webp" },
+        });
+
+        const origin = new URL(c.req.url).origin;
+        return c.json({ url: `${origin}/img/${photoId}?w=${width}`, cached: false, width });
+      } catch (error) {
+        return c.json({ error: "Transform failed" }, 500);
+      }
     }
-
-    if (!photo) return c.json({ error: "Photo not found" }, 404);
-
-    const r2Key = `${photo.r2_key}/w${w}.webp`;
-
-    const existing = await env.R2_IMAGES.get(r2Key);
-    if (existing) {
-      const origin = new URL(c.req.url).origin;
-      return c.json({ url: `${origin}/img/${photoId}?w=${w}`, cached: true, width: w });
-    }
-
-    const originalKey = `${photo.r2_key}/original.${photo.format}`;
-    const original = await env.R2_IMAGES.get(originalKey);
-    if (!original) return c.json({ error: "Original not found" }, 404);
-
-    try {
-      const transformed = await env.IMAGES.input(original.body)
-        .transform({ width: w, fit: "scale-down" })
-        .output({ format: "image/webp", quality: 85 });
-
-      const buffer = await transformed.response().arrayBuffer();
-      await env.R2_IMAGES.put(r2Key, buffer, {
-        httpMetadata: { contentType: "image/webp" },
-      });
-
-      const origin = new URL(c.req.url).origin;
-      return c.json({ url: `${origin}/img/${photoId}?w=${w}`, cached: false, width: w });
-    } catch (error) {
-      return c.json({ error: "Transform failed" }, 500);
-    }
-  });
+  );
 
   // POST /api/admin/photos/extract-colors - Extract accent colors for photos missing them
   // Can be called via MCP or admin UI to batch-process photos
-  app.post("/api/admin/photos/extract-colors", async (c) => {
-    const body = await c.req.json().catch(() => ({}));
-    const limit = Math.min(body.limit || 50, 100); // Max 100 per batch
-    const photoId = body.photoId; // Optional: process single photo
+  app.post(
+    "/api/admin/photos/extract-colors",
+    zValidator("json", extractColorsSchema, (result, c) => {
+      if (!result.success) {
+        return c.json({ error: formatValidationError(result.error) }, 400);
+      }
+    }),
+    async (c) => {
+      const { limit, photoId } = c.req.valid("json");
 
-    let photos: Photo[];
+      let photos: Photo[];
     
     if (photoId) {
       // Single photo mode
@@ -839,7 +892,8 @@ export function createPhotosApp(env: PhotosApiEnv) {
       remaining: remaining?.count || 0,
       results,
     });
-  });
+    }
+  );
 
   // POST /api/admin/upload - Upload new photo
   app.post("/api/admin/photos/upload", async (c) => {

--- a/utils/photos-api.ts
+++ b/utils/photos-api.ts
@@ -15,18 +15,9 @@ import {
   updatePhotoSchema,
   resizePhotoSchema,
   extractColorsSchema,
+  photoListQuerySchema,
+  formatZodError,
 } from "../src/lib/schemas";
-
-/**
- * Format Zod validation errors into a user-friendly message.
- * Inline to avoid Zod v4 type compatibility issues with exported function.
- */
-function formatValidationError(error: { issues: { path: PropertyKey[]; message: string }[] }): string {
-  return error.issues.map(issue => {
-    const path = issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : ''
-    return `${path}${issue.message}`
-  }).join('; ')
-}
 
 // Generate a short URL-safe ID from any string (used for cleaner /img/{id} URLs)
 // Must match the Python: hashlib.sha256(input.encode()).hexdigest()[:8]
@@ -451,14 +442,11 @@ export function createPhotosApp(env: PhotosApiEnv) {
 
   // GET /api/photos
   app.get("/api/photos", async (c) => {
-    const url = new URL(c.req.url);
-    const site = url.searchParams.get("site");
-
-    const limitParam = parseInt(url.searchParams.get("limit") || "50", 10);
-    const limit = Number.isNaN(limitParam) ? 50 : Math.min(Math.max(1, limitParam), 100);
-
-    const offsetParam = parseInt(url.searchParams.get("offset") || "0", 10);
-    const offset = Number.isNaN(offsetParam) ? 0 : Math.max(0, offsetParam);
+    const parsed = photoListQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) {
+      return c.json({ error: formatZodError(parsed.error) }, 400);
+    }
+    const { site, limit, offset } = parsed.data;
 
     let query = "SELECT * FROM photos WHERE exclude = 0";
     const params: (string | number)[] = [];
@@ -638,7 +626,7 @@ export function createPhotosApp(env: PhotosApiEnv) {
     "/api/admin/photos/:id",
     zValidator("json", updatePhotoSchema, (result, c) => {
       if (!result.success) {
-        return c.json({ error: formatValidationError(result.error) }, 400);
+        return c.json({ error: formatZodError(result.error) }, 400);
       }
     }),
     async (c) => {
@@ -751,7 +739,7 @@ export function createPhotosApp(env: PhotosApiEnv) {
     "/api/admin/photos/resize",
     zValidator("json", resizePhotoSchema, (result, c) => {
       if (!result.success) {
-        return c.json({ error: formatValidationError(result.error) }, 400);
+        return c.json({ error: formatZodError(result.error) }, 400);
       }
     }),
     async (c) => {
@@ -805,7 +793,7 @@ export function createPhotosApp(env: PhotosApiEnv) {
     "/api/admin/photos/extract-colors",
     zValidator("json", extractColorsSchema, (result, c) => {
       if (!result.success) {
-        return c.json({ error: formatValidationError(result.error) }, 400);
+        return c.json({ error: formatZodError(result.error) }, 400);
       }
     }),
     async (c) => {
@@ -921,7 +909,14 @@ export function createPhotosApp(env: PhotosApiEnv) {
 
     const id = crypto.randomUUID().replace(/-/g, "").slice(0, 12);
     const shortId = await generateShortId(id);
-    const format = file.type === "image/png" ? "png" : "jpeg";
+    
+    // Map MIME type to format (fixes WebP being stored as "jpeg")
+    const formatMap: Record<string, string> = {
+      "image/jpeg": "jpeg",
+      "image/png": "png",
+      "image/webp": "webp",
+    };
+    const format = formatMap[file.type] ?? "jpeg";
     const r2Key = `photos/${id}`;
 
     const arrayBuffer = await file.arrayBuffer();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Pure unit tests run in Node. Workers/D1-backed integration tests can opt
+    // into a Miniflare/workers pool separately when added.
+    environment: 'node',
+    // Test file patterns
+    include: ['tests/**/*.test.ts'],
+    // Coverage configuration
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.ts', 'utils/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/env.d.ts'],
+    },
+    // Globals for cleaner test syntax
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
Hardens the Notion→D1 sync and photos API for type safety, input validation, and error handling, then drives the codebase to a clean \`astro check\` (0 errors / 0 warnings) and scaffolds Biome for linting. Built on the original codex-compliance work; the last two commits squash-merge the type-error cleanup and lint setup.

## Key Changes
- **Notion sync correctness** (`src/pages/api/cron.ts`): store `notion_id` for climbs/peaks/gear (was silently NULL, breaking body sync), report accurate insert-vs-update counts, and extract shared parsing helpers into `src/lib/notion-helpers.ts` (also fixes `parseAreaFallback` mangling hyphenated areas like `Bridger-Teton`).
- **Cloudflare env typing** (`src/env.d.ts`): merge bindings into the global `Cloudflare.Env` interface so `env.DB`/`R2_IMAGES`/`IMAGES` resolve everywhere (cleared ~26 errors).
- **Photos API** (`utils/photos-api.ts`, route files): validate the `GET /api/photos` query with Zod, dedupe Zod error formatting, build the Hono app once per isolate instead of per request.
- **Type errors → 0** (`merge: type errs`): typed DOM queries as `HTMLElement` + null guards in client scripts (index, peaks, admin/climbs, blog, about), typed `D1.first()` rows, narrowed filtered arrays, dropped the removed `platformProxy` adapter option, `z` from `astro/zod`, widened the seed generic, asserted the BGE embedding shape.
- **Tests** (`tests/`, `vitest.config.ts`): vitest + 36 unit tests covering the extracted sync helpers (imported, not duplicated).
- **Lint** (`merge: lint`): Biome dep + config + `lint`/`lint:fix` scripts, tuned to repo style. Not yet applied repo-wide.

## Test Steps
1. `npm test` → 36/36 pass
2. `npx astro check` → 0 errors, 0 warnings (4 pre-existing `.mjs` hints remain)
3. `npm run build` → completes
4. Manual: hit `/`, `/peaks` (filter buttons), `/about`, a blog post — render with no console errors (verified locally after seeding D1)

## Risks / Follow-ups
- **After merge, run `npm run lint:fix`** for Biome's first repo-wide format pass (deliberately deferred to keep this diff reviewable).
- `notion_id` backfill depends on migrations `0006`/`0007` being applied to remote D1.
- 4 unused-var hints remain in `scripts/migrate/*.mjs` (unrelated tooling; left untouched).
- `astro check` requires `@astrojs/check` (already installed locally); not added to deps here.